### PR TITLE
Devel/4.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ RUN chmod 775 my_scripts/*
 RUN /my_scripts/install_r_packages.sh
 RUN /my_scripts/install_pandas.sh
 RUN /my_scripts/install_radian.sh
-RUN /my_scripts/install_notocjk.sh 
-#RUN /my_scripts/install_notojp.sh
+#RUN /my_scripts/install_notocjk.sh 
+RUN /my_scripts/install_notojp.sh
 RUN /my_scripts/install_coding_fonts.sh
 
 USER rstudio

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # rocker/tidyverse に日本語設定と頻用パッケージ、および TinyTeX, Radian を追加
-#   CRAN snapshot: https://packagemanager.rstudio.com/cran/__linux__/focal/2021-08-09
+#   CRAN snapshot: https://packagemanager.rstudio.com/cran/__linux__/focal/2021-10-29
 
-FROM rocker/tidyverse:4.1.0
+FROM rocker/tidyverse:4.1.1
 
 # Ubuntuミラーサイトの設定（自動選択）
 RUN sed -i.bak -e 's%http://[^ ]\+%mirror://mirrors.ubuntu.com/mirrors.txt%g' /etc/apt/sources.list

--- a/README.md
+++ b/README.md
@@ -16,16 +16,18 @@
 
 - Ubuntu の `language-pack-ja`, `language-pack-ja-base`
 - 環境変数で `ja_JP.UTF-8` ロケールとタイムゾーン `Asia/Tokyo` を指定
-- グラフ、PDF出力用フォントは下記のいずれか
-    - <s>IPAex明朝/ゴシック（Ubuntu の `fonts-ipaexfont` パッケージ）</s>
-    - Noto Sans/Serif JP（[Google Fonts](https://fonts.google.com/) で配布されている日本語サブセット版）
+- グラフ、PDF出力用フォントとして Noto フォントを追加
     - Noto Sans/Serif CJK JP
         - Ubuntu の `fonts-noto-cjk` パッケージのみでは XeLaTeX + BXjscls で日本語PDFを作成するのに不足あり
-        - `fonts-noto-cjk-extra` は KR, SC, TC のフォントを含むので巨大
-        - 容量節約のため、[Google Noto Fonts](https://www.google.com/get/noto/) からOTF版をダウンロードして JP の必要なウェイトを手動でインストールする
+        - `fonts-noto-cjk-extra` は KR, SC, TC のフォントも含むので巨大
+        - [Google Noto Fonts](https://www.google.com/get/noto/) は Google Fonts にリダイレクトされるようになった
+    - **Noto Sans/Serif JP**
+        - 現在、[Noto Home - Google Fonts](https://fonts.google.com/noto) で配布されているのは "CJK" なしの Noto Sans/Serif JP
+        - Google Fonts からダウンロードして、XeLaTeX + BXjscls で "noto-jp" を指定する場合に必要な ７フォントを手動でインストール
+        - 過去コードの文字化け回避のため、Noto Sans/Serif CJK JP を Noto Sans/Serif JP の別名として登録
 - RStudioのエディタで使用するコーディング用フォントとして以下を追加
     - [JetBrains Mono](https://www.jetbrains.com/ja-jp/lp/mono/) : リガチャで `->` や native pipe `|>` が特別な記号になる
-    - [PlemolJP](https://qiita.com/tawara_/items/0a7b8c50a48ea86b2d91) : IBM Plex Sans JP + IBM Plex Mono. 半角3:全角5のバージョンを採用
+    - [PlemolJP](https://qiita.com/tawara_/items/0a7b8c50a48ea86b2d91) : IBM Plex Sans JP + IBM Plex Mono. 3:5版ではなく通常版を使用
 
 ### radian: A 21 century R console
 
@@ -70,4 +72,5 @@
 - **2021-04-13** :bookmark:[4.0.3_update2104](https://github.com/mokztk/RStudio_docker/releases/tag/4.0.3_update2104) : 4.0.3_TL2020 の修正版
 - **2021-08-30** :bookmark:[4.1.0_2021Aug](https://github.com/mokztk/RStudio_docker/releases/tag/4.1.0_2021Aug) : `rocker/tidyverse:4.1.0` にあわせて更新。coding font 追加
 - **2021-09-22** :bookmark:[4.1.0_2021Aug_r2](https://github.com/mokztk/RStudio_docker/releases/tag/4.1.0_2021Aug_r2) : PlemolJP フォントを最新版に差し替え（記号のズレ対策）
+- **2021-11-11** :bookmark:[4.1.1_2021Oct](https://github.com/mokztk/RStudio_docker/releases/tag/4.1.1_2021Oct) : `rocker/tidyverse:4.1.1` にあわせて更新。フォント周りを中心に整理
 

--- a/README.md
+++ b/README.md
@@ -16,18 +16,15 @@
 
 - Ubuntu の `language-pack-ja`, `language-pack-ja-base`
 - 環境変数で `ja_JP.UTF-8` ロケールとタイムゾーン `Asia/Tokyo` を指定
-- グラフ、PDF出力用フォントとして Noto フォントを追加
-    - Noto Sans/Serif CJK JP
-        - Ubuntu の `fonts-noto-cjk` パッケージのみでは XeLaTeX + BXjscls で日本語PDFを作成するのに不足あり
-        - `fonts-noto-cjk-extra` は KR, SC, TC のフォントも含むので巨大
-        - [Google Noto Fonts](https://www.google.com/get/noto/) は Google Fonts にリダイレクトされるようになった
-    - **Noto Sans/Serif JP**
-        - 現在、[Noto Home - Google Fonts](https://fonts.google.com/noto) で配布されているのは "CJK" なしの Noto Sans/Serif JP
-        - Google Fonts からダウンロードして、XeLaTeX + BXjscls で "noto-jp" を指定する場合に必要な ７フォントを手動でインストール
-        - 過去コードの文字化け回避のため、Noto Sans/Serif CJK JP を Noto Sans/Serif JP の別名として登録
+- グラフ、PDF出力用フォントとして Noto Sans/Serif JP （"CJK" なし）を追加
+    - Ubuntu の `fonts-noto-cjk` パッケージのみでは XeLaTeX + BXjscls で日本語PDFを作成するのに不足するウェイトがある
+    - `fonts-noto-cjk-extra` は KR, SC, TC のフォントも含むので用途に対して大きすぎる（インストールサイズ 300MBほど）
+    - 現在、[Noto Home - Google Fonts](https://fonts.google.com/noto) で配布されているのは "CJK" なしの Noto Sans/Serif JP のみ
+    - Google Fonts からダウンロードして、XeLaTeX + BXjscls で "noto-jp" を指定する場合に必要な ７フォントを手動でインストールする
+    - 過去コードの文字化け回避のため、Noto Sans/Serif CJK JP を Noto Sans/Serif JP の別名として登録しておく
 - RStudioのエディタで使用するコーディング用フォントとして以下を追加
     - [JetBrains Mono](https://www.jetbrains.com/ja-jp/lp/mono/) : リガチャで `->` や native pipe `|>` が特別な記号になる
-    - [PlemolJP](https://qiita.com/tawara_/items/0a7b8c50a48ea86b2d91) : IBM Plex Sans JP + IBM Plex Mono. 3:5版ではなく通常版を使用
+    - [PlemolJP](https://qiita.com/tawara_/items/0a7b8c50a48ea86b2d91) : IBM Plex Sans JP + IBM Plex Mono。3:5版ではなく通常版を使用
 
 ### radian: A 21 century R console
 

--- a/my_scripts/fonts.conf
+++ b/my_scripts/fonts.conf
@@ -4,23 +4,26 @@
     <alias>
         <family>serif</family>
         <prefer>
-            <family>Noto Serif CJK JP</family>
             <family>Noto Serif JP</family>
-            <family>IPAex明朝</family>
         </prefer>
     </alias>
     <alias>
         <family>sans-serif</family>
         <prefer>
-            <family>Noto Sans CJK JP</family>
             <family>Noto Sans JP</family>
-            <family>IPAexゴシック</family>
+        </prefer>
+    </alias>
+    
+    <alias>
+        <family>Noto Serif CJK JP</family>
+        <prefer>
+            <family>Noto Serif JP</family>
         </prefer>
     </alias>
     <alias>
-        <family>monospace</family>
+        <family>Noto Sans CJK JP</family>
         <prefer>
-            <family>Noto Sans Mono CJK JP</family>
+            <family>Noto Sans JP</family>
         </prefer>
     </alias>
 </fontconfig>

--- a/my_scripts/install_coding_fonts.sh
+++ b/my_scripts/install_coding_fonts.sh
@@ -12,16 +12,15 @@ rm -rf JetBrainsMono
 
 ## PlemolJP (IBM Plex Sans JP + IBM Plex Mono)
 ##   https://qiita.com/tawara_/items/0a7b8c50a48ea86b2d91
-mkdir -p /home/rstudio/.config/rstudio/fonts/PlemolJP35Console/400/italic
-mkdir -p /home/rstudio/.config/rstudio/fonts/PlemolJP35Console/700/italic
-wget https://github.com/yuru7/PlemolJP/releases/download/v0.4.0/PlemolJP_v0.4.0.zip
-unzip PlemolJP_v0.4.0.zip
-cp PlemolJP_v0.4.0/PlemolJP35Console/PlemolJP35Console-Regular.ttf /home/rstudio/.config/rstudio/fonts/PlemolJP35Console/400
-cp PlemolJP_v0.4.0/PlemolJP35Console/PlemolJP35Console-Italic.ttf /home/rstudio/.config/rstudio/fonts/PlemolJP35Console/400/italic
-cp PlemolJP_v0.4.0/PlemolJP35Console/PlemolJP35Console-Bold.ttf /home/rstudio/.config/rstudio/fonts/PlemolJP35Console/700
-cp PlemolJP_v0.4.0/PlemolJP35Console/PlemolJP35Console-BoldItalic.ttf /home/rstudio/.config/rstudio/fonts/PlemolJP35Console/700/italic
-mv /home/rstudio/.config/rstudio/fonts/PlemolJP35Console/ /home/rstudio/.config/rstudio/fonts/PlemolJP35\ Console/
-rm PlemolJP_v0.4.0.zip
-rm -rf PlemolJP_v0.4.0
+mkdir -p /home/rstudio/.config/rstudio/fonts/PlemolJP/400/italic
+mkdir -p /home/rstudio/.config/rstudio/fonts/PlemolJP/700/italic
+wget -q https://github.com/yuru7/PlemolJP/releases/download/v1.2.0/PlemolJP_v1.2.0.zip
+unzip PlemolJP_v1.2.0.zip
+cp PlemolJP_v1.2.0/PlemolJP35Console/PlemolJP-Regular.ttf /home/rstudio/.config/rstudio/fonts/PlemolJP/400
+cp PlemolJP_v1.2.0/PlemolJP35Console/PlemolJP-Italic.ttf /home/rstudio/.config/rstudio/fonts/PlemolJP/400/italic
+cp PlemolJP_v1.2.0/PlemolJP35Console/PlemolJP-Bold.ttf /home/rstudio/.config/rstudio/fonts/PlemolJP/700
+cp PlemolJP_v1.2.0/PlemolJP35Console/PlemolJP-BoldItalic.ttf /home/rstudio/.config/rstudio/fonts/PlemolJP/700/italic
+rm PlemolJP_v1.2.0.zip
+rm -rf PlemolJP_v1.2.0
 
 chown -R rstudio:rstudio /home/rstudio/.config/rstudio

--- a/my_scripts/install_notojp.sh
+++ b/my_scripts/install_notojp.sh
@@ -1,28 +1,34 @@
 #!/bin/bash
 
 # Noto Sans/Serif JP フォントのインストール
-# Google Fonts でwebフォント用に配布されている日本語のみのサブセット版
-#
-# フォントのアドレスは Google Fonts Developer API のテスト画面から見られるJSONより抜粋したもの。
-# インストールされるフォント名はCJKなしの "Noto Sans/Serif JP"
-# zxjafont.sty のプリセット名は "noto-jp" を使う。
+# apt で fonts-noto-cjk + fonts-noto-cjk-extra を入れると300MB超となるため最低限のものを手動で導入する
+
+# Google Fonts で配布されている日本語フォントが "CJK" なしの Noto Sans/Serif JP になった
+# ファイルサイズは webフォント版と同じようだが、Google Fonts の配布パッケージのものを使用する
+# zxjafont.sty のプリセット名は "noto" ではなく、"noto-jp" を使う
 
 set -x
 
-mkdir /usr/share/fonts/notojp
+wget -q -O NotoSansJP.zip https://fonts.google.com/download?family=Noto%20Sans%20JP
+wget -q -O NotoSerifJP.zip https://fonts.google.com/download?family=Noto%20Serif%20JP
+unzip NotoSansJP.zip NotoSans*.otf
+unzip NotoSerifJP.zip NotoSerif*.otf
 
-wget -q -O /usr/share/fonts/notojp/NotoSerifJP-Light.otf http://fonts.gstatic.com/s/notoserifjp/v7/xn77YHs72GKoTvER4Gn3b5eMZHKMRkgfU8fEwb0.otf
-wget -q -O /usr/share/fonts/notojp/NotoSerifJP-Regular.otf http://fonts.gstatic.com/s/notoserifjp/v7/xn7mYHs72GKoTvER4Gn3b5eMXNikYkY0T84.otf
-wget -q -O /usr/share/fonts/notojp/NotoSerifJP-Bold.otf http://fonts.gstatic.com/s/notoserifjp/v7/xn77YHs72GKoTvER4Gn3b5eMZGKLRkgfU8fEwb0.otf
-wget -q -O /usr/share/fonts/notojp/NotoSansJP-Regular.otf http://fonts.gstatic.com/s/notosansjp/v27/-F62fjtqLzI2JPCgQBnw7HFowAIO2lZ9hg.otf
-wget -q -O /usr/share/fonts/notojp/NotoSansJP-Bold.otf http://fonts.gstatic.com/s/notosansjp/v27/-F6pfjtqLzI2JPCgQBnw7HFQei0q1H1hj-sNFQ.otf
-wget -q -O /usr/share/fonts/notojp/NotoSansJP-Black.otf http://fonts.gstatic.com/s/notosansjp/v27/-F6pfjtqLzI2JPCgQBnw7HFQQi8q1H1hj-sNFQ.otf
-wget -q -O /usr/share/fonts/notojp/NotoSansJP-Medium.otf http://fonts.gstatic.com/s/notosansjp/v27/-F6pfjtqLzI2JPCgQBnw7HFQMisq1H1hj-sNFQ.otf
+mkdir /usr/share/fonts/notojp
+mv NotoSerifJP-Light.otf /usr/share/fonts/notojp/
+mv NotoSerifJP-Regular.otf /usr/share/fonts/notojp/
+mv NotoSerifJP-Bold.otf /usr/share/fonts/notojp/
+mv NotoSansJP-Regular.otf /usr/share/fonts/notojp/
+mv NotoSansJP-Bold.otf /usr/share/fonts/notojp/
+mv NotoSansJP-Black.otf /usr/share/fonts/notojp/
+mv NotoSansJP-Medium.otf /usr/share/fonts/notojp/
 
 chmod 644 /usr/share/fonts/notojp/*
 fc-cache -fv
+rm Noto*
 
 # 標準フォントとして手動で入れた Noto fonts を認識できるようにする
+# Noto Sans/Serif CJK JP を Noto Sans/Serif JP の別名として登録しておく（過去のコードの文字化け回避）
 # 設定しておけば、最低限グラフの文字化けはなくなる
 
 mkdir -p /home/rstudio/.config/fontconfig

--- a/utils/tex_test.Rmd
+++ b/utils/tex_test.Rmd
@@ -6,7 +6,7 @@ output:
     keep_tex: false
     toc: false
 documentclass: bxjsarticle
-classoption: a4paper,xelatex,ja=standard,jafont=noto
+classoption: a4paper,xelatex,ja=standard,jafont=noto-jp
 ---
 
 ```{r setup, include=FALSE}
@@ -14,7 +14,7 @@ library(tidyverse)
 library(knitr)
 
 # グラフはcairo_pdfで出力するようにして日本語フォントを指定
-knitr::opts_chunk$set(dev="cairo_pdf", dev.args=list(family="Noto Sans CJK JP"))
+knitr::opts_chunk$set(dev="cairo_pdf", dev.args=list(family="Noto Sans JP"))
 ```
 
 ## テスト


### PR DESCRIPTION
rocker/tidyverse:4.1.1 対応版
- Google Noto Fonts で Noto Sans/Serif CJK JP が配布されなくなったため、CJKなしの Noto Sans/Serif JP に変更
- fonts.conf で Noto Sans/Serif CJK JP を Noto Sans/Serif JP の別名として登録
- PlemolJP を最新の 1.2.0 に更新。RStudio Console での見やすさから 3:5版ではなく 1:2版に変更