### PR TITLE
Devel/4.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
 # rocker/tidyverse に日本語設定と頻用パッケージ、および TinyTeX, Radian を追加
-#   2022-06-02 の rocker/tidyverse:4.2.0 および RSPM を使用
+#   ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/2022-06-22
 
-#FROM rocker/tidyverse:4.2.0
-FROM rocker/tidyverse@sha256:3ff87598467da673421880dc24ffc7270a9e10147620003a35db8193636066fe
-
-# RSPM を latest から 2022-06-02 に固定
-RUN sed -i.bak -e 's%focal/latest%focal/2022-06-02%' /usr/local/lib/R/etc/Rprofile.site
+FROM rocker/tidyverse:4.2.0
+#FROM rocker/tidyverse@sha256:f50a823199a9c98b68f5393c3282dd978d8bfc3efe3a59f13f8b789a49daf4af
 
 # Ubuntuミラーサイトの設定（自動選択）
 RUN sed -i.bak -e 's%http://[^ ]\+%mirror://mirrors.ubuntu.com/mirrors.txt%g' /etc/apt/sources.list

--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@
 
 - これまでインストールしていたものを整理して利用頻度が少ない大物を中心に削除
 - 容量節約のため、`--deps TRUE`指定（依存関係 Suggestsまで含める）は外し、インストール後にDLしたアーカイブは削除
+- rockerのスクリプトに倣い、インストール後にRSPMのバイナリパッケージで導入された *.so を整理
 
 ### Quarto
 - https://quarto.org/
-- CRANレポジトリに合わせて、2022-06-02時点の最新版 Preview v0.9 Build 504 を使用
-- Rパッケージ `quarto` もインストール
+- `/rocker_scripts/install_quarto.sh` で RStudio にバンドルされているもの（`QUARTO_VERSION=default`）をインストール
+- Rパッケージ `quarto` もインストールし RStudio で使えるようにする
 
 ### Python3 & radian: A 21 century R console
 
@@ -75,3 +76,4 @@
 - **2021-09-22** :bookmark:[4.1.0_2021Aug_r2](https://github.com/mokztk/RStudio_docker/releases/tag/4.1.0_2021Aug_r2) : PlemolJP フォントを最新版に差し替え（記号のズレ対策）
 - **2021-11-11** :bookmark:[4.1.1_2021Oct](https://github.com/mokztk/RStudio_docker/releases/tag/4.1.1_2021Oct) : `rocker/tidyverse:4.1.1` にあわせて更新。フォント周りを中心に整理
 - **2022-06-07** :bookmark:[4.2.0_2022Jun](https://github.com/mokztk/RStudio_docker/releases/tag/4.2.0_2022Jun) : ベースを `rocker/tidyverse:4.2.0` （2022-06-02版）に更新。Quartoの導入、フォントの変更など
+- **2022-06-24** :bookmark:[4.2.0_2022Jun_2](https://github.com/mokztk/RStudio_docker/releases/tag/4.2.0_2022Jun_2) : ベースを `rocker/tidyverse:4.2.0` snapshot確定版に更新。Quarto関係を修正

--- a/my_scripts/install_coding_fonts.sh
+++ b/my_scripts/install_coding_fonts.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -x
+
 # Install coding fonts (for RStudio Server)
 
 ## UDEV Gothic LG (BIZ UD Gothic + JetBrains Mono)

--- a/my_scripts/install_quarto.sh
+++ b/my_scripts/install_quarto.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
 set -x
 
-# Quarto のインストール
+# rocker/tidyvese 内に RStudio server のバンドルですでにインストールされているものを
+# /rocker_scripts/install_quarto.sh でセットアップする
 
-apt-get update
+QUARTO_VERSION="default" /rocker_scripts/install_quarto.sh
 
-QUARTO_DEB="quarto-0.9.504-linux-amd64.deb"
-wget -q https://github.com/quarto-dev/quarto-cli/releases/download/v0.9.504/${QUARTO_DEB}
-gdebi -n $QUARTO_DEB
-rm $QUARTO_DEB
+# R の {quarto} パッケージをインストール
+# Ref: https://github.com/rocker-org/rocker-versioned2/commit/75dd95c6cee7da29ceed363b9fe4823a12f575f8
 
-apt-get clean
-rm -rf /var/lib/apt/lists/*
+install2.r --error --ncpus -1 --skipinstalled \
+    knitr \
+    quarto
 
-install2.r --error --ncpus -1 --skipinstalled quarto
+# Clean up
+rm -rf /tmp/downloaded_packages
+
+## Strip binary installed lybraries from RSPM
+## https://github.com/rocker-org/rocker-versioned2/issues/340
+strip /usr/local/lib/R/site-library/*/libs/*.so

--- a/my_scripts/install_r_packages.sh
+++ b/my_scripts/install_r_packages.sh
@@ -19,6 +19,8 @@ apt-get install -y --no-install-recommends \
     libjpeg-dev \
     libpng-dev \
     libssl-dev \
+    libtcl8.6 \
+    libtk8.6 \
     libv8-dev \
     libxft-dev \
     libxml2-dev \
@@ -26,9 +28,6 @@ apt-get install -y --no-install-recommends \
 
 apt-get clean
 rm -rf /var/lib/apt/lists/*
-
-# rJava の設定
-R CMD javareconf
 
 # RSPMのcheckpointが変わった場合に対応するため、まずcheckpointの状態まで更新する
 Rscript -e "update.packages(ask = FALSE)"
@@ -84,5 +83,10 @@ install2.r --error --ncpus -1 --skipinstalled \
 # installGithub.r tomwenseleers/export@1afc8e2
 Rscript -e "remotes::install_github('tomwenseleers/export@1afc8e2')"
  
-# cleaning
-rm /tmp/downloaded_packages/*
+# Clean up
+# Ref: https://github.com/rocker-org/rocker-versioned2/commit/75dd95c6cee7da29ceed363b9fe4823a12f575f8
+rm -rf /tmp/downloaded_packages
+
+## Strip binary installed lybraries from RSPM
+## https://github.com/rocker-org/rocker-versioned2/issues/340
+strip /usr/local/lib/R/site-library/*/libs/*.so


### PR DESCRIPTION
- ベースを rocker/tidyverse:4.2.0 snapshot 確定版（2022-06-22）に更新
- rocker のスクリプトに倣い、RSPM からのインストール後に *.so を整理
- Quarto は RStudio にバンドルされているものを /rocker_scripts/install_quarto.sh でインストール
