### PR TITLE
Devel/4.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # rocker/tidyverse に日本語設定と頻用パッケージ、および TinyTeX, Radian を追加
-#   ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/2022-06-22
+#   ENV CRAN=https://packagemanager.posit.co/cran/__linux__/jammy/2023-03-14
 
-FROM rocker/tidyverse:4.2.0
-#FROM rocker/tidyverse@sha256:f50a823199a9c98b68f5393c3282dd978d8bfc3efe3a59f13f8b789a49daf4af
+FROM rocker/tidyverse:4.2.2
 
-# Ubuntuミラーサイトの設定（自動選択）
-RUN sed -i.bak -e 's%http://[^ ]\+%mirror://mirrors.ubuntu.com/mirrors.txt%g' /etc/apt/sources.list
+# Ubuntuミラーサイトの設定
+#RUN sed -i.bak -e 's%http://[^ ]\+%mirror://mirrors.ubuntu.com/mirrors.txt%g' /etc/apt/sources.list
+RUN sed -i.bak -e "s%http://[^ ]\+%http://ftp.udx.icscoe.jp/Linux/ubuntu/%g" /etc/apt/sources.list
 
 # 日本語設定と必要なライブラリ（Rパッケージ用は別途スクリプト内で導入）
 RUN set -x \

--- a/Dockerfile_arm64
+++ b/Dockerfile_arm64
@@ -1,0 +1,80 @@
+# rocker/r-ver:4.2.2 (ARM) をベースにRStudio, tidyverse, 日本語設定等を追加する
+#   ENV CRAN=https://packagemanager.posit.co/cran/__linux__/jammy/2023-03-14
+
+# rocker/tidyverse:4.2.2 の Dockerfile を参考にベースを構築
+#  https://github.com/rocker-org/rocker-versioned2/blob/master/dockerfiles/rstudio_4.2.2.Dockerfile
+#  https://github.com/rocker-org/rocker-versioned2/blob/master/dockerfiles/tidyverse_4.2.2.Dockerfile
+
+FROM --platform=arm64 rocker/r-ver:4.2.2 AS tidyverse
+
+ENV S6_VERSION=v2.1.0.2
+ENV RSTUDIO_VERSION=2023.03.0+386
+ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
+
+RUN /rocker_scripts/install_rstudio.sh
+RUN /rocker_scripts/install_pandoc.sh
+
+# arm64 では rocker 公式スクリプトでQuarto のインストールはスキップされるので、Release Candidate Builds をインストール
+RUN set -x \
+    && apt-get update \
+    && wget https://github.com/quarto-dev/quarto-cli/releases/download/v1.3.302/quarto-1.3.302-linux-arm64.deb -O quarto.deb \
+    && dpkg -i quarto.deb \
+    && rm quarto.deb \
+    && quarto check install \
+    && install2.r --error --skipinstalled knitr quarto \
+    && rm -rf /tmp/downloaded_packages \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY my_scripts/install_tidyverse.sh /my_scripts/install_tidyverse.sh
+RUN chmod 775 /my_scripts/install_tidyverse.sh \
+    && /my_scripts/install_tidyverse.sh
+
+EXPOSE 8787
+
+CMD ["/init"]
+
+# 上記の rocker/tidyverse 相当のイメージに日本語設定などを追加
+# arm 非対応なので TinyTeX のセットアップは行わない
+
+FROM tidyverse
+
+# 日本語設定と必要なライブラリ（Rパッケージ用は別途スクリプト内で導入）
+RUN set -x \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        language-pack-ja-base \
+        libxt6 \
+        ssh \
+    && /usr/sbin/update-locale LANG=ja_JP.UTF-8 LANGUAGE="ja_JP:ja" \
+    && /bin/bash -c "source /etc/default/locale" \
+    && ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup script
+# 各スクリプトは改行コード LF(UNIX) でないとエラーになる
+COPY my_scripts /my_scripts
+RUN chmod 775 my_scripts/*
+RUN /my_scripts/install_r_packages.sh
+RUN /my_scripts/install_radian.sh
+RUN /my_scripts/install_notojp.sh
+RUN /my_scripts/install_coding_fonts.sh
+
+USER rstudio
+
+# ${R_HOME}/etc/Renviron のタイムゾーン指定（Etc/UTC）を上書き
+RUN echo "TZ=Asia/Tokyo" >> /home/rstudio/.Renviron
+
+# 検証用ファイル
+COPY --chown=rstudio:rstudio utils /home/rstudio/utils
+
+USER root
+ENV LANG=ja_JP.UTF-8 \
+    LC_ALL=ja_JP.UTF-8 \
+    TZ=Asia/Tokyo \
+    PASSWORD=password \
+    DISABLE_AUTH=true
+
+CMD ["/init"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # About this image
 
 - **rocker/tidyverse** に日本語設定、頻用パッケージ、TinyTeX関係をインストールした作業用イメージ
+    - ARM64 版も rocker/r-ver を出発点に rocker/tidyverse ＋日本語設定、頻用パッケージを導入する
 - RStudio server を開くまでもないような作業用に、[radian: A 21 century R console](https://github.com/randy3k/radian)を追加する
 - `reticulate` で最低限の python 連携も使用できるようにする
 - [rocker-org/rocker-versioned2](https://github.com/rocker-org/rocker-versioned2) のように、目的別のスクリプトを使って Dockerfile 自体は極力シンプルにしてみる
@@ -9,8 +10,8 @@
 
 ### Ubuntu mirror
 
-- 自動選択の `mirror://mirrors.ubuntu.com/mirrors.txt` に変更
-- Ref: https://blog.amedama.jp/entry/2019/09/11/234050
+- x86_64 の場合は日本のミラーサーバーで一番回線が太い ICSCoE（IPA産業サイバーセキュリティセンター）に変更
+- arm64 は置かれていないミラーサーバーも多いので変更しない
 
 ### 日本語環境、フォント
 
@@ -32,14 +33,15 @@
 
 ### R の頻用パッケージ
 
-- これまでインストールしていたものを整理して利用頻度が少ない大物を中心に削除
 - 容量節約のため、`--deps TRUE`指定（依存関係 Suggestsまで含める）は外し、インストール後にDLしたアーカイブは削除
 - rockerのスクリプトに倣い、インストール後にRSPMのバイナリパッケージで導入された *.so を整理
+- arm64版では、容量の大きな dbplyr database backend は省略
 
 ### Quarto
 - https://quarto.org/
-- `/rocker_scripts/install_quarto.sh` で RStudio にバンドルされているもの（`QUARTO_VERSION=default`）をインストール
-- Rパッケージ `quarto` もインストールし RStudio で使えるようにする
+- x86_64 では `/rocker_scripts/install_quarto.sh` で RStudio にバンドルされているもの（`QUARTO_VERSION=default`）をインストール
+- arm64 では手動で v1.3.302 Release Candidate Build をインストール
+- Rパッケージ `quarto` もインストールし R Console からも使えるようにする（arm版では RStudio 上でうまく変換できない）
 
 ### Python3 & radian: A 21 century R console
 
@@ -50,12 +52,13 @@
 
 ### TinyTeX
 
-- 2022年3月末で TeX Live 2021 が更新終了（frozen）となったので、日本語 TeX 開発コミュニティ texjp.org のサーバにあるTeX Live 2021 のアーカイブを利用する
-- TinyTeX はそれに合わせて "2022.03" をインストール
+- 2023年3月で TeX Live 2022 が更新終了（frozen）となったので、日本語 TeX 開発コミュニティ texjp.org のサーバにあるTeX Live 2022 のアーカイブを利用する
+- TinyTeX はそれに合わせて "2023.03" をインストール
 - TinyTeX のセットアップまで行い、その他に必要なパッケージは自動インストールに任せる
     - 初回に日本語PDFを作成するときに自動でインストールされる（XeLaTeX + BXjscls の文書で約50個）
     - LuaLaTeXの場合、原ノ味フォントはインストールしておかないと進まなくなるので `haranoaji` だけ手動で入れておく
     - `/my_scripts/install_tex_packages.sh` をユーザー rstudio 権限で実行してインストールすることも可能
+- arm64 は非対応なので、セットアップは行わない
 
 ### 環境変数 PASSWORD の仮設定
 
@@ -77,3 +80,4 @@
 - **2021-11-11** :bookmark:[4.1.1_2021Oct](https://github.com/mokztk/RStudio_docker/releases/tag/4.1.1_2021Oct) : `rocker/tidyverse:4.1.1` にあわせて更新。フォント周りを中心に整理
 - **2022-06-07** :bookmark:[4.2.0_2022Jun](https://github.com/mokztk/RStudio_docker/releases/tag/4.2.0_2022Jun) : ベースを `rocker/tidyverse:4.2.0` （2022-06-02版）に更新。Quartoの導入、フォントの変更など
 - **2022-06-24** :bookmark:[4.2.0_2022Jun_2](https://github.com/mokztk/RStudio_docker/releases/tag/4.2.0_2022Jun_2) : ベースを `rocker/tidyverse:4.2.0` snapshot確定版に更新。Quarto関係を修正
+- **2023-04-06** :bookmark:[4.2.2_2023Mar](https://github.com/mokztk/RStudio_docker/releases/tag/4.2.2_2023Mar) : `rocker/tidyverse:4.2.2` にあわせて更新。ARM64版を試作

--- a/my_scripts/install_coding_fonts.sh
+++ b/my_scripts/install_coding_fonts.sh
@@ -7,12 +7,12 @@ set -x
 ##   https://github.com/yuru7/udev-gothic
 mkdir -p /home/rstudio/.config/rstudio/fonts/UDEVGothicLG/400/italic
 mkdir -p /home/rstudio/.config/rstudio/fonts/UDEVGothicLG/700/italic
-wget -q https://github.com/yuru7/udev-gothic/releases/download/v1.0.0/UDEVGothic_v1.0.0.zip
-unzip UDEVGothic_v1.0.0.zip
-cp UDEVGothic_v1.0.0/UDEVGothicLG-Regular.ttf /home/rstudio/.config/rstudio/fonts/UDEVGothicLG/400
-cp UDEVGothic_v1.0.0/UDEVGothicLG-Italic.ttf /home/rstudio/.config/rstudio/fonts/UDEVGothicLG/400/italic
-cp UDEVGothic_v1.0.0/UDEVGothicLG-Bold.ttf /home/rstudio/.config/rstudio/fonts/UDEVGothicLG/700
-cp UDEVGothic_v1.0.0/UDEVGothicLG-BoldItalic.ttf /home/rstudio/.config/rstudio/fonts/UDEVGothicLG/700/italic
+wget -q https://github.com/yuru7/udev-gothic/releases/download/v1.1.0/UDEVGothic_v1.1.0.zip -O UDEVGothic.zip
+unzip UDEVGothic.zip
+cp UDEVGothic/UDEVGothicLG-Regular.ttf /home/rstudio/.config/rstudio/fonts/UDEVGothicLG/400
+cp UDEVGothic/UDEVGothicLG-Italic.ttf /home/rstudio/.config/rstudio/fonts/UDEVGothicLG/400/italic
+cp UDEVGothic/UDEVGothicLG-Bold.ttf /home/rstudio/.config/rstudio/fonts/UDEVGothicLG/700
+cp UDEVGothic/UDEVGothicLG-BoldItalic.ttf /home/rstudio/.config/rstudio/fonts/UDEVGothicLG/700/italic
 mv /home/rstudio/.config/rstudio/fonts/UDEVGothicLG/ /home/rstudio/.config/rstudio/fonts/UDEV\ Gothic\ LG/
 rm -rf UDEVGothic*
 

--- a/my_scripts/install_r_packages.sh
+++ b/my_scripts/install_r_packages.sh
@@ -16,6 +16,7 @@ apt-get install -y --no-install-recommends \
     libglpk-dev \
     libglu1-mesa-dev \
     libgmp3-dev \
+    libicu-dev \
     libjpeg-dev \
     libpng-dev \
     libssl-dev \
@@ -43,8 +44,9 @@ install2.r --error --ncpus -1 --skipinstalled \
     pROC \
     cmprsk \
     psych \
-    clinfun \
     car \
+    mice \
+    ggmice \
     survminer \
     GGally \
     ggfortify \
@@ -62,27 +64,13 @@ install2.r --error --ncpus -1 --skipinstalled \
     DiagrammeR \
     palmerpenguins \
     styler \
-    svglite
+    svglite \
+    export
 
 # R.cache (imported by styler) で使用するキャッシュディレクトリを準備
 mkdir -p /home/rstudio/.cache/R/R.cache
 chown -R rstudio:rstudio /home/rstudio/.cache
 
-# since package "export" was removed from CRAN on 2020-02-21,
-# install dev version from GitHub repo (commit 1afc8e2 / 2021-03-09)
-install2.r --error --ncpus -1 --skipinstalled \
-    officer \
-    rvg \
-    openxlsx \
-    flextable \
-    xtable \
-    rgl \
-    stargazer \
-    devEMF
-
-# installGithub.r tomwenseleers/export@1afc8e2
-Rscript -e "remotes::install_github('tomwenseleers/export@1afc8e2')"
- 
 # Clean up
 # Ref: https://github.com/rocker-org/rocker-versioned2/commit/75dd95c6cee7da29ceed363b9fe4823a12f575f8
 rm -rf /tmp/downloaded_packages

--- a/my_scripts/install_tidyverse.sh
+++ b/my_scripts/install_tidyverse.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -x
+
+# rocker/tidyverse 相当のパッケージを導入
+# 容量の大きな database backend は RSQLite 以外省略
+# Ref: https://github.com/rocker-org/rocker-versioned2/blob/master/scripts/install_tidyverse.sh
+
+# 依存ライブラリの追加
+apt-get update
+apt-get install -y --no-install-recommends \
+    libxml2-dev \
+    libcairo2-dev \
+    libgit2-dev \
+    default-libmysqlclient-dev \
+    libpq-dev \
+    libsasl2-dev \
+    libsqlite3-dev \
+    libssh2-1-dev \
+    libxtst6 \
+    libcurl4-openssl-dev \
+    libharfbuzz-dev \
+    libfribidi-dev \
+    libfreetype6-dev \
+    libpng-dev \
+    libtiff5-dev \
+    libjpeg-dev \
+    unixodbc-dev
+
+# R packages
+install2.r --error --skipinstalled \
+    tidyverse \
+    devtools \
+    rmarkdown \
+    BiocManager \
+    vroom \
+    gert
+
+## dplyr database backends
+install2.r --error --skipmissing --skipinstalled \
+    dbplyr \
+    DBI \
+    RSQLite \
+    fst
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+rm -rf /tmp/downloaded_packages
+
+## Strip binary installed lybraries from RSPM
+## https://github.com/rocker-org/rocker-versioned2/issues/340
+strip /usr/local/lib/R/site-library/*/libs/*.so

--- a/my_scripts/install_tinytex.sh
+++ b/my_scripts/install_tinytex.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # TinyTex本体のインストール
-# 当面、FREEZEとなった TeXLive 2021 アーカイブを利用する
+# 当面、FREEZEとなった TeXLive 2022 アーカイブを利用する
 
-Rscript -e 'tinytex::install_tinytex(dir = "/home/rstudio/.TinyTeX/", version = "2022.03", repository = "https://texlive.texjp.org/2021/tlnet")'
+Rscript -e 'tinytex::install_tinytex(dir = "/home/rstudio/.TinyTeX/", version = "2023.03", repository = "https://texlive.texjp.org/2022/tlnet")'
 
 # 原ノ味フォントをインストールしておく（その他は、必要時に tlmgr で自動的にインストールされる）
 Rscript -e 'tinytex::tlmgr_install("haranoaji")'


### PR DESCRIPTION
rocker/tidyverse:4.2.2 ベースに更新
- [x86_64] ubuntu ミラーを国内サーバーに変更
- [x86_64] TinyTeX を TeXLive 2022 FROZEN に更新
- インストールする R パッケージの見直し
- ARM64 版を試作
    - rocker/r-ver:4.2.2 から rocker/tidyvese:4.2.2 相当のイメージを作成し、そこに追加（multistage build）
    - Quarto は RC bulid を手動インストール。RStudioからは上手く動かないので Console で `quarto::render()` など
    - 容量の大きな database backend は省略
    - TinyTeX は arm64 非対応なのでセットアップは行わない
  