### PR TITLE
Devel/4.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN set -x \
 COPY my_scripts /my_scripts
 RUN chmod 775 my_scripts/*
 RUN /my_scripts/install_r_packages.sh
-RUN /my_scripts/install_quarto.sh
 RUN /my_scripts/install_radian.sh
 RUN /my_scripts/install_notojp.sh
 RUN /my_scripts/install_coding_fonts.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # rocker/tidyverse に日本語設定と頻用パッケージ、および TinyTeX, Radian を追加
-#   ENV CRAN=https://packagemanager.posit.co/cran/__linux__/jammy/2023-03-14
+#   ENV CRAN=https://packagemanager.posit.co/cran/__linux__/jammy/2023-06-14
 
-FROM rocker/tidyverse:4.2.2
+FROM rocker/tidyverse:4.3.0
 
 # Ubuntuミラーサイトの設定
 #RUN sed -i.bak -e 's%http://[^ ]\+%mirror://mirrors.ubuntu.com/mirrors.txt%g' /etc/apt/sources.list

--- a/Dockerfile_arm64
+++ b/Dockerfile_arm64
@@ -1,37 +1,17 @@
-# rocker/r-ver:4.3.0 (ARM) をベースにRStudio, tidyverse, 日本語設定等を追加する
+# rocker/rstudio:4.3.0 (ARM) をベースにtidyverse, 日本語設定等を追加する
 #   ENV CRAN=https://packagemanager.posit.co/cran/__linux__/jammy/2023-06-14
 
 # rocker/tidyverse:4.3.0 の Dockerfile を参考にベースを構築
 #  https://github.com/rocker-org/rocker-versioned2/blob/master/dockerfiles/rstudio_4.3.0.Dockerfile
 #  https://github.com/rocker-org/rocker-versioned2/blob/master/dockerfiles/tidyverse_4.3.0.Dockerfile
 
-FROM --platform=arm64 rocker/r-ver:4.3.0 AS tidyverse
+FROM --platform=arm64 rocker/rstudio:4.3.0 AS tidyverse
 
-ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=2023.06.0+421
-ENV DEFAULT_USER=rstudio
-ENV PANDOC_VERSION=default
-
-RUN /rocker_scripts/install_rstudio.sh
-RUN /rocker_scripts/install_pandoc.sh
-
-# arm64 では rocker 公式スクリプトでQuarto のインストールはスキップされるので、公式サイトから Linux Arm64 版をインストール
-RUN set -x \
-    && apt-get update \
-    && wget https://github.com/quarto-dev/quarto-cli/releases/download/v1.3.361/quarto-1.3.361-linux-arm64.deb -O quarto.deb \
-    && dpkg -i quarto.deb \
-    && rm quarto.deb \
-    && quarto check install \
-    && install2.r --error --skipinstalled knitr quarto \
-    && rm -rf /tmp/downloaded_packages \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+# rocker/rstudio:4.3.0 の中を見るとQuartoも導入されているので、tidyverse の追加だけ行う
 
 COPY my_scripts/install_tidyverse.sh /my_scripts/install_tidyverse.sh
 RUN chmod 775 /my_scripts/install_tidyverse.sh \
     && /my_scripts/install_tidyverse.sh
-
-EXPOSE 8787
 
 CMD ["/init"]
 
@@ -75,6 +55,10 @@ ENV LANG=ja_JP.UTF-8 \
     LC_ALL=ja_JP.UTF-8 \
     TZ=Asia/Tokyo \
     PASSWORD=password \
-    DISABLE_AUTH=true
+    DISABLE_AUTH=true \
+    RUNROOTLESS=false
+
+# Arm64版のrocker/rstudio:4.3.0はrootlessモードで動いているが、Amd64版との整合性のため
+# rootlessモードは解除しておく
 
 CMD ["/init"]

--- a/Dockerfile_arm64
+++ b/Dockerfile_arm64
@@ -1,24 +1,24 @@
-# rocker/r-ver:4.2.2 (ARM) をベースにRStudio, tidyverse, 日本語設定等を追加する
-#   ENV CRAN=https://packagemanager.posit.co/cran/__linux__/jammy/2023-03-14
+# rocker/r-ver:4.3.0 (ARM) をベースにRStudio, tidyverse, 日本語設定等を追加する
+#   ENV CRAN=https://packagemanager.posit.co/cran/__linux__/jammy/2023-06-14
 
-# rocker/tidyverse:4.2.2 の Dockerfile を参考にベースを構築
-#  https://github.com/rocker-org/rocker-versioned2/blob/master/dockerfiles/rstudio_4.2.2.Dockerfile
-#  https://github.com/rocker-org/rocker-versioned2/blob/master/dockerfiles/tidyverse_4.2.2.Dockerfile
+# rocker/tidyverse:4.3.0 の Dockerfile を参考にベースを構築
+#  https://github.com/rocker-org/rocker-versioned2/blob/master/dockerfiles/rstudio_4.3.0.Dockerfile
+#  https://github.com/rocker-org/rocker-versioned2/blob/master/dockerfiles/tidyverse_4.3.0.Dockerfile
 
-FROM --platform=arm64 rocker/r-ver:4.2.2 AS tidyverse
+FROM --platform=arm64 rocker/r-ver:4.3.0 AS tidyverse
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=2023.03.0+386
+ENV RSTUDIO_VERSION=2023.06.0+421
 ENV DEFAULT_USER=rstudio
 ENV PANDOC_VERSION=default
 
 RUN /rocker_scripts/install_rstudio.sh
 RUN /rocker_scripts/install_pandoc.sh
 
-# arm64 では rocker 公式スクリプトでQuarto のインストールはスキップされるので、Release Candidate Builds をインストール
+# arm64 では rocker 公式スクリプトでQuarto のインストールはスキップされるので、公式サイトから Linux Arm64 版をインストール
 RUN set -x \
     && apt-get update \
-    && wget https://github.com/quarto-dev/quarto-cli/releases/download/v1.3.302/quarto-1.3.302-linux-arm64.deb -O quarto.deb \
+    && wget https://github.com/quarto-dev/quarto-cli/releases/download/v1.3.361/quarto-1.3.361-linux-arm64.deb -O quarto.deb \
     && dpkg -i quarto.deb \
     && rm quarto.deb \
     && quarto check install \

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - 以下の日本語フォントを導入
     - **Noto Sans/Serif JP**（"CJK"なし）
         - `fonts-noto-cjk-extra` は KR, SC, TC のフォントも含むので用途に対して大きすぎる（インストールサイズ 300MBほど）
-        - [Google Fonts](https://fonts.google.com/) からダウンロードして、XeLaTeX + BXjscls で "noto-jp" を指定する場合に必要な ７フォントを手動でインストール
+        - Github [notofonts/noto-cjk](https://github.com/notofonts/noto-cjk) から個別のOTF版をダウンロードして、XeLaTeX + BXjscls で "noto-jp" を指定する場合に必要な ７フォントを手動でインストール
         - serif/sans の標準日本語フォントとして設定
         - 過去コードの文字化け回避のため、Noto Sans/Serif CJK JP を Noto Sans/Serif JP の別名として登録しておく
     - **[UDEV Gothic](https://github.com/yuru7/udev-gothic)**
@@ -40,7 +40,7 @@
 ### Quarto
 - https://quarto.org/
 - x86_64 では `/rocker_scripts/install_quarto.sh` で RStudio にバンドルされているもの（`QUARTO_VERSION=default`）をインストール
-- arm64 では手動で v1.3.302 Release Candidate Build をインストール
+- arm64 では公式で配布されている Linux Arm64 版を手動でインストール
 - Rパッケージ `quarto` もインストールし R Console からも使えるようにする（arm版では RStudio 上でうまく変換できない）
 
 ### Python3 & radian: A 21 century R console
@@ -49,6 +49,7 @@
 - rocker project で用意されている `/rocker_scripts/install_python.sh` を利用して Python3 をインストール
 - R から Python を使えるよう、`reticulate` に必要な Pandas などもインストール（`Seaborn` も含む）
 - radian のコード補完のためには `jedi` が必要なのであわせてインストール
+- python 3.10 の依存関係でトラブルが発生するので暫定的にダウングレード（3.10.6-1~22.04.2ubuntu1.1 -> 3.10.6-1~22.04.2ubuntu1）
 
 ### TinyTeX
 
@@ -81,3 +82,5 @@
 - **2022-06-07** :bookmark:[4.2.0_2022Jun](https://github.com/mokztk/RStudio_docker/releases/tag/4.2.0_2022Jun) : ベースを `rocker/tidyverse:4.2.0` （2022-06-02版）に更新。Quartoの導入、フォントの変更など
 - **2022-06-24** :bookmark:[4.2.0_2022Jun_2](https://github.com/mokztk/RStudio_docker/releases/tag/4.2.0_2022Jun_2) : ベースを `rocker/tidyverse:4.2.0` snapshot確定版に更新。Quarto関係を修正
 - **2023-04-06** :bookmark:[4.2.2_2023Mar](https://github.com/mokztk/RStudio_docker/releases/tag/4.2.2_2023Mar) : `rocker/tidyverse:4.2.2` にあわせて更新。ARM64版を試作
+- **2023-06-21** :bookmark:[4.2.2_2023Mar_2](https://github.com/mokztk/RStudio_docker/releases/tag/4.2.2_2023Mar_2) : Noto Sans JP フォントの導入に失敗していたのを修正
+- **2023-06-23** :bookmark:[4.3.0_2023Jul](https://github.com/mokztk/RStudio_docker/releases/tag/4.3.0_2023Jul) : `rocker/tidyverse:4.3.0` にあわせて更新

--- a/README.md
+++ b/README.md
@@ -37,15 +37,13 @@
 - rockerのスクリプトに倣い、インストール後にRSPMのバイナリパッケージで導入された *.so を整理
 - arm64版では、容量の大きな dbplyr database backend は省略
 
-### Quarto
-- https://quarto.org/
-- x86_64 では `/rocker_scripts/install_quarto.sh` で RStudio にバンドルされているもの（`QUARTO_VERSION=default`）をインストール
-- arm64 では公式で配布されている Linux Arm64 版を手動でインストール
-- Rパッケージ `quarto` もインストールし R Console からも使えるようにする（arm版では RStudio 上でうまく変換できない）
+### [Quarto](https://quarto.org/)
 
-### Python3 & radian: A 21 century R console
+- x86_64, arm64 とも rocker/rstudio で既に導入されている
+- Rパッケージ `quarto` もインストールし R Console からも使えるようにする
 
-- https://github.com/randy3k/radian
+### Python3 & [radian: A 21 century R console](https://github.com/randy3k/radian)
+
 - rocker project で用意されている `/rocker_scripts/install_python.sh` を利用して Python3 をインストール
 - R から Python を使えるよう、`reticulate` に必要な Pandas などもインストール（`Seaborn` も含む）
 - radian のコード補完のためには `jedi` が必要なのであわせてインストール
@@ -65,6 +63,12 @@
 
 - Docker Desktop など `-e PASSWORD=...` が設定できないGUIでも起動テストできるように仮のパスワードを埋め込んでおく
 - 更に、普段使いのため `DISABLE_AUTH=true` を埋め込む。パスワードが必要なときは、起動時に `-e DISABLE_AUTH=false`
+
+### rootless モードの解除 (Arm64)
+
+- arm64版の rocker/rstudio (rocker/r-ver に RStudio Server を追加した場合も) は rootless モードで動いており、起動時にユーザー rstudio が削除される
+- amd64(x86_64)版と設定ファイルなどを共用するために rootless モードを解除して、従来どおりユーザー rstudio を使用する
+- 今後、amd64 も rootless になるようならば要検討
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - Ubuntu の `language-pack-ja`, `language-pack-ja-base`
 - 環境変数で `ja_JP.UTF-8` ロケールとタイムゾーン `Asia/Tokyo` を指定
 - 以下の日本語フォントを導入
-    - **Noto Sans/Serif JP**（"CJK"なし）
+    - **[Noto Sans/Serif JP](https://fonts.google.com/noto/fonts)**（"CJK"なし）
         - `fonts-noto-cjk-extra` は KR, SC, TC のフォントも含むので用途に対して大きすぎる（インストールサイズ 300MBほど）
         - Github [notofonts/noto-cjk](https://github.com/notofonts/noto-cjk) から個別のOTF版をダウンロードして、XeLaTeX + BXjscls で "noto-jp" を指定する場合に必要な ７フォントを手動でインストール
         - serif/sans の標準日本語フォントとして設定
@@ -49,7 +49,7 @@
 - rocker project で用意されている `/rocker_scripts/install_python.sh` を利用して Python3 をインストール
 - R から Python を使えるよう、`reticulate` に必要な Pandas などもインストール（`Seaborn` も含む）
 - radian のコード補完のためには `jedi` が必要なのであわせてインストール
-- python 3.10 の依存関係でトラブルが発生するので暫定的にダウングレード（3.10.6-1~22.04.2ubuntu1.1 -> 3.10.6-1~22.04.2ubuntu1）
+- python 3.10 の依存関係でトラブルが発生するので暫定的にダウングレード（3.10.6-1\~22.04.2ubuntu1.1 -> 3.10.6-1\~22.04.2ubuntu1）
 
 ### TinyTeX
 

--- a/my_scripts/install_coding_fonts.sh
+++ b/my_scripts/install_coding_fonts.sh
@@ -7,7 +7,7 @@ set -x
 ##   https://github.com/yuru7/udev-gothic
 mkdir -p /home/rstudio/.config/rstudio/fonts/UDEVGothicLG/400/italic
 mkdir -p /home/rstudio/.config/rstudio/fonts/UDEVGothicLG/700/italic
-wget -q https://github.com/yuru7/udev-gothic/releases/download/v1.1.0/UDEVGothic_v1.1.0.zip -O UDEVGothic.zip
+wget -q https://github.com/yuru7/udev-gothic/releases/download/v1.3.0/UDEVGothic_v1.3.0.zip -O UDEVGothic.zip
 unzip -j -d UDEVGothic UDEVGothic.zip
 cp UDEVGothic/UDEVGothicLG-Regular.ttf /home/rstudio/.config/rstudio/fonts/UDEVGothicLG/400
 cp UDEVGothic/UDEVGothicLG-Italic.ttf /home/rstudio/.config/rstudio/fonts/UDEVGothicLG/400/italic

--- a/my_scripts/install_pandas.sh
+++ b/my_scripts/install_pandas.sh
@@ -4,6 +4,15 @@ set -x
 
 # R から {reticulate} で Python3 を使えるようにセットアップ
 
+# python 3.10 関連の依存関係のトラブルに対する workaround
+cat << EOF >> /etc/apt/preferences
+Package: *python3.10*
+Pin: version 3.10.6-1~22.04.2ubuntu1
+Pin-Priority: 1000
+EOF
+apt-get update
+apt-get install -y --allow-downgrades python3.10
+
 # Python3のインストール
 source /rocker_scripts/install_python.sh
 

--- a/my_scripts/install_r_packages.sh
+++ b/my_scripts/install_r_packages.sh
@@ -38,6 +38,8 @@ Rscript -e "update.packages(ask = FALSE)"
 install2.r --error --ncpus -1 --skipinstalled \
     here \
     pacman \
+    knitr \
+    quarto \
     tidylog \
     furrr \
     glmnetUtils \

--- a/my_scripts/install_radian.sh
+++ b/my_scripts/install_radian.sh
@@ -20,7 +20,7 @@ options(radian.highlight_matching_bracket = TRUE)
 options(radian.prompt = "\033[0;32mr$>\033[0m ")
 options(radian.escape_key_map = list(
   list(key = "-", value = " <- "),
-  list(key = "m", value = " %>% ")
+  list(key = "m", value = " |> ")
 ))
 options(radian.force_reticulate_python = TRUE)
 EOF


### PR DESCRIPTION
rocker/tidyverse:4.3.0 ベースに更新
- Quartoはrockerのイメージで導入済みのものを使用するように変更
- Noto Sans/Serif JP フォントを Github から個別にダウンロードするように変更
- Python 3.10 まわりの依存性問題回避のためダウングレードを実施
- ARM64 版
    - rocker/rstudio:4.3.0 の Arm64版が Docker Hub に公開されたのでベースイメージを変更
    - rootlessモードで動いているため、Amd64と設定ファイルなどを共用するため USEROOTLESS=false