### PR TITLE
Devel/4.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,10 @@ ENV LANG=ja_JP.UTF-8 \
     DISABLE_AUTH=true \
     RUNROOTLESS=false
 
+# SSHDを起動できるように準備
+RUN mkdir /var/run/sshd
+
+EXPOSE 22
+EXPOSE 8787
+
 CMD ["/init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN set -x \
 # 各スクリプトは改行コード LF(UNIX) でないとエラーになる
 COPY my_scripts /my_scripts
 RUN chmod 775 my_scripts/*
-RUN /my_scripts/install_r_packages.sh
+RUN /my_scripts/install_r_packages_pak.sh
 RUN /my_scripts/install_radian.sh
 RUN /my_scripts/install_notojp.sh
 RUN /my_scripts/install_coding_fonts.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-# rocker/rstudio:4.4.2 をベースにtidyverse, 日本語設定等を追加する（amd64/arm64共通）
-#   ENV CRAN="https://p3m.dev/cran/__linux__/noble/2025-02-27"
+# rocker/rstudio:4.5.0 をベースにtidyverse, 日本語設定等を追加する（amd64/arm64共通）
+#   ENV CRAN="https://p3m.dev/cran/__linux__/noble/2025-06-12"
 
-# rocker/tidyverse:4.4.2 の Dockerfile を参考にベースを構築
-#  https://github.com/rocker-org/rocker-versioned2/blob/master/dockerfiles/rstudio_4.4.2.Dockerfile
-#  https://github.com/rocker-org/rocker-versioned2/blob/master/dockerfiles/tidyverse_4.4.2.Dockerfile
+# rocker/tidyverse:4.5.0 の Dockerfile を参考にベースを構築
+#  https://github.com/rocker-org/rocker-versioned2/blob/master/dockerfiles/rstudio_4.5.0.Dockerfile
+#  https://github.com/rocker-org/rocker-versioned2/blob/master/dockerfiles/tidyverse_4.5.0.Dockerfile
 
-FROM rocker/rstudio:4.4.2 AS tidyverse
+FROM rocker/rstudio:4.5.0 AS tidyverse
 
 # rocker/tidyverse 相当のパッケージを導入
-# 容量の大きな database backend は RSQLite 以外省略
+# 容量の大きな database backend は RSQLite 以外省略（行番号は @5d33fd1 対応）
 RUN sed -e 48d -e 52,56d /rocker_scripts/install_tidyverse.sh | bash
 
 CMD ["/init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN /my_scripts/install_r_packages_pak.sh
 RUN /my_scripts/install_radian.sh
 RUN /my_scripts/install_notojp.sh
 RUN /my_scripts/install_coding_fonts.sh
+RUN /my_scripts/install_msedit.sh
 
 # 検証用ファイル
 COPY --chown=rstudio:rstudio utils /home/rstudio/utils

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 - **rocker/rstudio** に rocker/tidyverse 相当のパッケージと日本語設定、頻用パッケージをインストールした作業用イメージ
     - rocker/rstudio を出発点にすることで Amd64 (x86_64) / Arm64 の Dockerfile を共通化
     - rocker/tidyverse 相当のうち、容量の大きな dbplyr database backend は RSQLite 以外を省略
-- RStudio server を開くまでもないような作業用に、[radian: A 21 century R console](https://github.com/randy3k/radian)を追加する
+- CLI作業用に、[radian: A 21 century R console](https://github.com/randy3k/radian) と [Microsoft Edit](https://github.com/microsoft/edit) を追加する
 - `reticulate` で最低限の python 連携も使用できるようにする
 - [rocker-org/rocker-versioned2](https://github.com/rocker-org/rocker-versioned2) のように、目的別のスクリプトを使って Dockerfile 自体は極力シンプルにしてみる
 
 ```
-docker image build -t "mokztk/rstudio:4.4.2" .
-docker run --rm -d -p 8787:8787 --name rstudio mokztk/rstudio:4.4.2
+docker image build -t "mokztk/rstudio:4.5.0" .
+docker run --rm -d -p 8787:8787 --name rstudio mokztk/rstudio:4.5.0
 
 # rocker/tidyverse 相当までの build
-docker image build --target tidyverse -t "mokztk/tidyverse:4.4.2" .
+docker image build --target tidyverse -t "mokztk/tidyverse:4.5.0" .
 ```
 
 ## 詳細
@@ -28,6 +28,7 @@ arm64 が置かれていないミラーサーバーも多いので変更しな�
 - 以下の日本語フォントを導入
     - **[Noto Sans/Serif JP](https://fonts.google.com/noto/fonts)**（"CJK"なし）
         - `fonts-noto-cjk-extra` は KR, SC, TC のフォントも含むので用途に対して大きすぎる（インストールサイズ 300MBほど）
+        - Windows 11 に搭載された Noto Sans/Serif JP（"CJK"なし）と作図コードに互換性が確保できる
         - Github [notofonts/noto-cjk](https://github.com/notofonts/noto-cjk) から個別のOTF版をダウンロードして、XeLaTeX + BXjscls で "noto-jp" を指定する場合に必要な ７フォントと Noto Sans Mono CJK JP を手動でインストール
         - serif/sans/monospace の標準日本語フォントとして設定
         - 過去コードの文字化け回避のため、Noto Sans/Serif CJK JP を Noto Sans/Serif JP の別名として登録しておく
@@ -39,12 +40,12 @@ arm64 が置かれていないミラーサーバーも多いので変更しな�
 ### R の頻用パッケージ
 
 - [インストール済みのパッケージ一覧](package_list.md)
-- 容量節約のため、`--deps TRUE`指定（依存関係 Suggestsまで含める）は外し、インストール後にDLしたアーカイブは削除
+- 容量節約のため、`dependencies = NA` の指定とし、インストール後にDLしたアーカイブは削除
 - rockerのスクリプトに倣い、インストール後にRSPMのバイナリパッケージで導入された *.so を整理
 
 ### [Quarto](https://quarto.org/) & [Typst](https://typst.app/)
 
-- rocker/rstudio:4.4.2 でインストール済のもので Typst によるPDF出力可能のため追加インストールはしない
+- rocker/rstudio:4.5.0 でインストール済のもので Typst によるPDF出力可能のため追加インストールはしない
 - Rパッケージ `quarto` もインストールし R Console からも使えるようにする
 
 ### Python3 & [radian: A 21 century R console](https://github.com/randy3k/radian)
@@ -61,6 +62,21 @@ radian をホストPCで使うときは
 ```
 docker exec -it <container name> /opt/venv/bin/radian
 ```
+
+### [Microsoft Edit](https://github.com/microsoft/edit)
+
+- CLI用のテキストエディタがないので、`msedit` の名前で使用できるように導入しておく
+
+### remote SSH接続
+
+[Positron](https://positron.posit.co/) などから remote SSH で接続できるよう、`sshd` の準備をしておく。ENTRYPOINT を上書きして
+
+```
+docker run --rm -d -p 22:22 --name r_ssh --entrypoint /bin/sh mokztk/rstudio:4.5.0 -c "/usr/sbin/sshd -D"
+```
+
+で起動すれば、パスワード認証（初期設定はユーザー、パスワードとも `rstudio`）での SSH 接続が可能。
+また、`/home/rstudio/.ssh/authorized_keys` に公開鍵を登録すればパスワード不要の公開鍵暗号での接続も可能。
 
 ### TinyTeX
 
@@ -103,3 +119,4 @@ docker exec -it <container name> /opt/venv/bin/radian
 - **2023-06-23** 🔖[4.3.0_2023Jun](https://github.com/mokztk/RStudio_docker/releases/tag/4.3.0_2023Jun) : `rocker/tidyverse:4.3.0` にあわせて更新
 - **2024-04-26** 🔖[4.3.3_2024Apr](https://github.com/mokztk/RStudio_docker/releases/tag/4.3.3_2024Apr) : `rocker/rstudio:4.3.3` をベースにQuarto 1.4を追加。Amd64/Arm64のDockerfileを1本化
 - **2025-03-06** 🔖[4.4.2_2025Mar](https://github.com/mokztk/RStudio_docker/releases/tag/4.4.2_2025Mar) : `rocker/rstudio:4.4.2` ベースに更新
+- **2025-06-15** 🔖[4.5.0_2025JUn](https://github.com/mokztk/RStudio_docker/releases/tag/4.5.0_2025Jun) : `rocker/rstudio:4.5.0` ベースに更新。remote SSH接続できるよう設定を追加

--- a/README.md
+++ b/README.md
@@ -43,11 +43,6 @@ arm64 が置かれていないミラーサーバーも多いので変更しな�
 - 容量節約のため、`dependencies = NA` の指定とし、インストール後にDLしたアーカイブは削除
 - rockerのスクリプトに倣い、インストール後にRSPMのバイナリパッケージで導入された *.so を整理
 
-### [Quarto](https://quarto.org/) & [Typst](https://typst.app/)
-
-- rocker/rstudio:4.5.0 でインストール済のもので Typst によるPDF出力可能のため追加インストールはしない
-- Rパッケージ `quarto` もインストールし R Console からも使えるようにする
-
 ### Python3 & [radian: A 21 century R console](https://github.com/randy3k/radian)
 
 - rocker project で用意されている `/rocker_scripts/install_python.sh` を利用して Python3 をインストール
@@ -72,25 +67,22 @@ docker exec -it <container name> /opt/venv/bin/radian
 [Positron](https://positron.posit.co/) などから remote SSH で接続できるよう、`sshd` の準備をしておく。ENTRYPOINT を上書きして
 
 ```
-docker run --rm -d -p 22:22 --name r_ssh --entrypoint /bin/sh mokztk/rstudio:4.5.0 -c "/usr/sbin/sshd -D"
+docker run --rm -d -p 22:22 --entrypoint /bin/sh mokztk/rstudio:4.5.0 -c "/usr/sbin/sshd -D"
 ```
 
 で起動すれば、パスワード認証（初期設定はユーザー、パスワードとも `rstudio`）での SSH 接続が可能。
-また、`/home/rstudio/.ssh/authorized_keys` に公開鍵を登録すればパスワード不要の公開鍵暗号での接続も可能。
+
+また、`/home/rstudio/.ssh/authorized_keys` に公開鍵を登録すればパスワード不要の公開鍵暗号での接続も可能になる。
 
 ### TinyTeX
 
 - Quarto-Typst で日本語PDFも作成できほぼ使わななくなったため、TinyTeX はパッケージはインストールしてあるがセットアップをしていない状態
-- 以下は4.3系以降メンテナンスしていないが、当時の方法では使えるはず
-    - 必要に応じてユーザー `rstudio` 権限でセットアップスクリプト `/my_script/install_tinytex.sh` を実行する（RStudio の Terminal で可）。
-        - TeX Live は引き続き日本語 TeX 開発コミュニティ texjp.org のサーバにある TeX Live 2022 (frozen) のアーカイブを利用
-        - TinyTeX はそれに合わせて "2023.03" をインストール
-        - LuaLaTeXの場合に、原ノ味フォントを先にインストールしておかないと進まなくなるので `haranoaji` だけセットアップ時にインストールしておく
-        - その他に必要なパッケージは、初回に日本語PDFを作成するときに自動でインストールされる（XeLaTeX + BXjscls の文書で約50個）
+- 必要に応じてユーザー `rstudio` 権限でセットアップスクリプト `/my_script/install_tinytex.sh` を実行する（RStudio の Terminal で可）
+    - R4.3系以降メンテナンスしていないが、TeX Live 2022 frozen ベースで LuaLaTeX / XeLaTeX で日本語PDFを作成できる環境が準備できるはず
 
-### 環境変数 PASSWORD の仮設定
+### 環境変数 PASSWORD の仮設定（RStudio Server のログインパスワード）
 
-- Docker Desktop など `-e PASSWORD=...` が設定できないGUIでも起動テストできるように仮のパスワードを埋め込んでおく
+- 初期パスワード `rstudio` のままでは RStudio Server が使用できないので、Docker Desktop など -e PASSWORD=... が設定できないGUIでも起動テストできるように仮のパスワード `password` を埋め込んでおく
 - 更に、普段使いのため `DISABLE_AUTH=true` を埋め込む。パスワードが必要なときは、起動時に `-e DISABLE_AUTH=false`
 
 ### rootless モードの解除 (Arm64)
@@ -119,4 +111,4 @@ docker run --rm -d -p 22:22 --name r_ssh --entrypoint /bin/sh mokztk/rstudio:4.5
 - **2023-06-23** 🔖[4.3.0_2023Jun](https://github.com/mokztk/RStudio_docker/releases/tag/4.3.0_2023Jun) : `rocker/tidyverse:4.3.0` にあわせて更新
 - **2024-04-26** 🔖[4.3.3_2024Apr](https://github.com/mokztk/RStudio_docker/releases/tag/4.3.3_2024Apr) : `rocker/rstudio:4.3.3` をベースにQuarto 1.4を追加。Amd64/Arm64のDockerfileを1本化
 - **2025-03-06** 🔖[4.4.2_2025Mar](https://github.com/mokztk/RStudio_docker/releases/tag/4.4.2_2025Mar) : `rocker/rstudio:4.4.2` ベースに更新
-- **2025-06-15** 🔖[4.5.0_2025JUn](https://github.com/mokztk/RStudio_docker/releases/tag/4.5.0_2025Jun) : `rocker/rstudio:4.5.0` ベースに更新。remote SSH接続できるよう設定を追加
+- **2025-06-15** 🔖[4.5.0_2025Jun](https://github.com/mokztk/RStudio_docker/releases/tag/4.5.0_2025Jun) : `rocker/rstudio:4.5.0` ベースに更新。remote SSH接続できるよう設定を追加

--- a/my_scripts/install_msedit.sh
+++ b/my_scripts/install_msedit.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/bash
+wget -O /tmp/msedit.tar.zst https://github.com/microsoft/edit/releases/download/v1.2.0/edit-1.2.0-`uname -m`-linux-gnu.tar.zst
+cd /tmp
+tar -Izstd -xvf msedit.tar.zst
+mv edit /usr/local/bin/msedit

--- a/my_scripts/install_r_packages_pak.sh
+++ b/my_scripts/install_r_packages_pak.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# R パッケージのインストール
+
+set -x
+
+apt-get update
+
+# まず最新の状態まで更新する
+Rscript -e "update.packages(ask = FALSE)"
+
+# pak::pak() を使うと依存ライブラリのインストールもしてくれる
+install2.r pak
+
+cat << EOF | R
+pak::pak(c(
+    "here",
+    "pacman",
+    "knitr",
+    "quarto",
+    "tidylog",
+    "furrr",
+    "glmnetUtils",
+    "glmmTMB",
+    "ggeffects",
+    "pROC",
+    "cmprsk",
+    "car",
+    "mice",
+    "ggmice",
+    "survminer",
+    "ggsurvfit",
+    "GGally",
+    "ggfortify",
+    "gghighlight",
+    "ggsci",
+    "ggrepel",
+    "patchwork",
+    "gt",
+    "gtsummary",
+    "flextable",
+    "formattable",
+    "ftExtra",
+    "minidown",
+    "DiagrammeR",
+    "palmerpenguins",
+    "basepenguins",
+    "styler",
+    "svglite",
+    "export",
+    "tidyplots",
+    "tinytable"
+))
+EOF
+
+# R.cache (imported by styler) で使用するキャッシュディレクトリを準備
+mkdir -p /home/rstudio/.cache/R/R.cache
+chown -R rstudio:rstudio /home/rstudio/.cache
+
+# Clean up
+# Ref: https://github.com/rocker-org/rocker-versioned2/commit/75dd95c6cee7da29ceed363b9fe4823a12f575f8
+rm -rf /tmp/downloaded_packages
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+
+## Strip binary installed lybraries from RSPM
+## https://github.com/rocker-org/rocker-versioned2/issues/340
+strip /usr/local/lib/R/site-library/*/libs/*.so

--- a/my_scripts/install_r_packages_pak.sh
+++ b/my_scripts/install_r_packages_pak.sh
@@ -6,11 +6,19 @@ set -x
 
 apt-get update
 
+# base の tcltk パッケージのために Tcl/Tk を入れておく
+apt-get install -y --no-install-recommends \
+    libtcl8.6 \
+    libtk8.6
+
 # まず最新の状態まで更新する
 Rscript -e "update.packages(ask = FALSE)"
 
 # pak::pak() を使うと依存ライブラリのインストールもしてくれる
-install2.r pak
+# (4.5.0) pak で RccpEigen がうまくインストールできないので、ここで入れておく
+install2.r --error --ncpus -1 --skipinstalled \
+    pak \
+    RcppEigen
 
 cat << EOF | R
 pak::pak(c(

--- a/package_list.md
+++ b/package_list.md
@@ -10,293 +10,294 @@ library(tidyverse)
 
 | package           | ondiskversion | date       | source         |
 |:------------------|:--------------|:-----------|:---------------|
-| abind             | 1.4-8         | 2024-09-12 | RSPM (R 4.4.0) |
-| askpass           | 1.2.1         | 2024-10-04 | RSPM (R 4.4.0) |
-| backports         | 1.5.0         | 2024-05-23 | RSPM (R 4.4.0) |
-| base64enc         | 0.1-3         | 2015-07-28 | RSPM (R 4.4.0) |
-| beeswarm          | 0.4.0         | 2021-06-01 | RSPM (R 4.4.0) |
-| bigD              | 0.3.0         | 2024-11-08 | RSPM (R 4.4.0) |
-| BiocManager       | 1.30.25       | 2024-08-28 | RSPM (R 4.4.0) |
-| bit               | 4.5.0.1       | 2024-12-03 | RSPM (R 4.4.0) |
-| bit64             | 4.6.0-1       | 2025-01-16 | RSPM (R 4.4.0) |
-| bitops            | 1.0-9         | 2024-10-03 | RSPM (R 4.4.0) |
-| blob              | 1.2.4         | 2023-03-17 | RSPM (R 4.4.0) |
-| boot              | 1.3-31        | 2024-08-28 | CRAN (R 4.4.2) |
-| brew              | 1.0-10        | 2023-12-16 | RSPM (R 4.4.0) |
-| brio              | 1.1.5         | 2024-04-24 | RSPM (R 4.4.0) |
-| broom             | 1.0.7         | 2024-09-26 | RSPM (R 4.4.0) |
-| bslib             | 0.9.0         | 2025-01-30 | RSPM (R 4.4.0) |
-| cachem            | 1.1.0         | 2024-05-16 | RSPM (R 4.4.0) |
-| Cairo             | 1.6-2         | 2023-11-28 | RSPM (R 4.4.0) |
-| callr             | 3.7.6         | 2024-03-25 | RSPM (R 4.4.0) |
-| car               | 3.1-3         | 2024-09-27 | RSPM (R 4.4.0) |
-| carData           | 3.0-5         | 2022-01-06 | RSPM (R 4.4.0) |
-| cards             | 0.5.0         | 2025-02-17 | RSPM (R 4.4.0) |
-| cellranger        | 1.1.0         | 2016-07-27 | RSPM (R 4.4.0) |
-| checkmate         | 2.3.2         | 2024-07-29 | RSPM (R 4.4.0) |
-| class             | 7.3-23        | 2025-01-01 | RSPM (R 4.4.0) |
-| cli               | 3.6.4         | 2025-02-13 | RSPM (R 4.4.0) |
-| clipr             | 0.8.0         | 2022-02-22 | RSPM (R 4.4.0) |
-| clisymbols        | 1.2.0         | 2017-05-21 | RSPM (R 4.4.0) |
-| cluster           | 2.1.8         | 2024-12-11 | RSPM (R 4.4.0) |
-| cmprsk            | 2.2-12        | 2024-05-19 | RSPM (R 4.4.0) |
-| codetools         | 0.2-20        | 2024-03-31 | CRAN (R 4.4.2) |
-| colorspace        | 2.1-1         | 2024-07-26 | RSPM (R 4.4.0) |
-| commonmark        | 1.9.2         | 2024-10-04 | RSPM (R 4.4.0) |
-| conflicted        | 1.2.0         | 2023-02-01 | RSPM (R 4.4.0) |
-| corrplot          | 0.95          | 2024-10-14 | RSPM (R 4.4.0) |
-| cowplot           | 1.1.3         | 2024-01-22 | RSPM (R 4.4.0) |
-| cpp11             | 0.5.1         | 2024-12-04 | RSPM (R 4.4.0) |
-| crayon            | 1.5.3         | 2024-06-20 | RSPM (R 4.4.0) |
-| credentials       | 2.0.2         | 2024-10-04 | RSPM (R 4.4.0) |
-| curl              | 6.2.1         | 2025-02-19 | RSPM (R 4.4.0) |
-| data.table        | 1.17.0        | 2025-02-22 | RSPM (R 4.4.0) |
-| datawizard        | 1.0.0         | 2025-01-10 | RSPM (R 4.4.0) |
-| DBI               | 1.2.3         | 2024-06-02 | RSPM (R 4.4.0) |
-| dbplyr            | 2.5.0         | 2024-03-19 | RSPM (R 4.4.0) |
-| Deriv             | 4.1.6         | 2024-09-13 | RSPM (R 4.4.0) |
-| desc              | 1.4.3         | 2023-12-10 | RSPM (R 4.4.0) |
-| devEMF            | 4.5           | 2024-07-26 | RSPM (R 4.4.0) |
-| devtools          | 2.4.5         | 2022-10-11 | RSPM (R 4.4.0) |
-| DiagrammeR        | 1.0.11        | 2024-02-02 | RSPM (R 4.4.0) |
-| diffobj           | 0.3.5         | 2021-10-05 | RSPM (R 4.4.0) |
-| digest            | 0.6.37        | 2024-08-19 | RSPM (R 4.4.0) |
-| doBy              | 4.6.25        | 2025-01-30 | RSPM (R 4.4.0) |
-| docopt            | 0.7.1         | 2020-06-24 | RSPM (R 4.4.2) |
-| downlit           | 0.4.4         | 2024-06-10 | RSPM (R 4.4.0) |
-| dplyr             | 1.1.4         | 2023-11-17 | RSPM (R 4.4.0) |
-| dtplyr            | 1.3.1         | 2023-03-22 | RSPM (R 4.4.0) |
-| ellipsis          | 0.3.2         | 2021-04-29 | RSPM (R 4.4.0) |
-| evaluate          | 1.0.3         | 2025-01-10 | RSPM (R 4.4.0) |
-| exactRankTests    | 0.8-35        | 2022-04-26 | RSPM (R 4.4.0) |
-| export            | 0.3.0         | 2022-12-07 | RSPM (R 4.4.0) |
-| fansi             | 1.0.6         | 2023-12-08 | RSPM (R 4.4.0) |
-| farver            | 2.1.2         | 2024-05-13 | RSPM (R 4.4.0) |
-| fastmap           | 1.2.0         | 2024-05-15 | RSPM (R 4.4.0) |
-| flextable         | 0.9.7         | 2024-10-27 | RSPM (R 4.4.0) |
-| fontawesome       | 0.5.3         | 2024-11-16 | RSPM (R 4.4.0) |
-| fontBitstreamVera | 0.1.1         | 2017-02-01 | RSPM (R 4.4.0) |
-| fontLiberation    | 0.1.0         | 2016-10-15 | RSPM (R 4.4.0) |
-| fontquiver        | 0.2.1         | 2017-02-01 | RSPM (R 4.4.0) |
-| forcats           | 1.0.0         | 2023-01-29 | RSPM (R 4.4.0) |
-| foreach           | 1.5.2         | 2022-02-02 | RSPM (R 4.4.0) |
-| foreign           | 0.8-88        | 2025-01-12 | RSPM (R 4.4.0) |
-| formattable       | 0.2.1         | 2021-01-07 | RSPM (R 4.4.0) |
-| Formula           | 1.2-5         | 2023-02-24 | RSPM (R 4.4.0) |
-| fs                | 1.6.5         | 2024-10-30 | RSPM (R 4.4.0) |
-| fst               | 0.9.8         | 2022-02-08 | RSPM (R 4.4.0) |
-| fstcore           | 0.10.0        | 2025-02-10 | RSPM (R 4.4.0) |
-| ftExtra           | 0.6.4         | 2024-05-10 | RSPM (R 4.4.0) |
-| furrr             | 0.3.1         | 2022-08-15 | RSPM (R 4.4.0) |
-| future            | 1.34.0        | 2024-07-29 | RSPM (R 4.4.0) |
-| gargle            | 1.5.2         | 2023-07-20 | RSPM (R 4.4.0) |
-| gdtools           | 0.4.1         | 2024-11-04 | RSPM (R 4.4.0) |
-| generics          | 0.1.3         | 2022-07-05 | RSPM (R 4.4.0) |
-| gert              | 2.1.4         | 2024-10-14 | RSPM (R 4.4.0) |
-| GGally            | 2.2.1         | 2024-02-14 | RSPM (R 4.4.0) |
-| ggbeeswarm        | 0.7.2         | 2023-04-29 | RSPM (R 4.4.0) |
-| ggeffects         | 2.2.0         | 2025-02-05 | RSPM (R 4.4.0) |
-| ggfortify         | 0.4.17        | 2024-04-17 | RSPM (R 4.4.0) |
-| gghighlight       | 0.4.1         | 2023-12-16 | RSPM (R 4.4.0) |
-| ggmice            | 0.1.0         | 2023-08-07 | RSPM (R 4.4.0) |
-| ggplot2           | 3.5.1         | 2024-04-23 | RSPM (R 4.4.0) |
-| ggpubr            | 0.6.0         | 2023-02-10 | RSPM (R 4.4.0) |
-| ggrastr           | 1.0.2         | 2023-06-01 | RSPM (R 4.4.0) |
-| ggrepel           | 0.9.6         | 2024-09-07 | RSPM (R 4.4.0) |
-| ggsci             | 3.2.0         | 2024-06-18 | RSPM (R 4.4.0) |
-| ggsignif          | 0.6.4         | 2022-10-13 | RSPM (R 4.4.0) |
-| ggstats           | 0.8.0         | 2025-01-07 | RSPM (R 4.4.0) |
-| ggsurvfit         | 1.1.0         | 2024-05-08 | RSPM (R 4.4.0) |
-| ggtext            | 0.1.2         | 2022-09-16 | RSPM (R 4.4.0) |
-| gh                | 1.4.1         | 2024-03-28 | RSPM (R 4.4.0) |
-| gitcreds          | 0.1.2         | 2022-09-08 | RSPM (R 4.4.0) |
-| glmmTMB           | 1.1.10        | 2024-09-26 | RSPM (R 4.4.0) |
-| glmnet            | 4.1-8         | 2023-08-22 | RSPM (R 4.4.0) |
-| glmnetUtils       | 1.1.9         | 2023-09-10 | RSPM (R 4.4.0) |
-| globals           | 0.16.3        | 2024-03-08 | RSPM (R 4.4.0) |
-| glue              | 1.8.0         | 2024-09-30 | RSPM (R 4.4.0) |
-| googledrive       | 2.1.1         | 2023-06-11 | RSPM (R 4.4.0) |
-| googlesheets4     | 1.1.1         | 2023-06-11 | RSPM (R 4.4.0) |
-| gridExtra         | 2.3           | 2017-09-09 | RSPM (R 4.4.0) |
-| gridtext          | 0.1.5         | 2022-09-16 | RSPM (R 4.4.0) |
-| gt                | 0.11.1        | 2024-10-04 | RSPM (R 4.4.0) |
-| gtable            | 0.3.6         | 2024-10-25 | RSPM (R 4.4.0) |
-| gtsummary         | 2.1.0         | 2025-02-19 | RSPM (R 4.4.0) |
-| haven             | 2.5.4         | 2023-11-30 | RSPM (R 4.4.0) |
-| here              | 1.0.1         | 2020-12-13 | RSPM (R 4.4.0) |
-| highr             | 0.11          | 2024-05-26 | RSPM (R 4.4.0) |
-| Hmisc             | 5.2-2         | 2025-01-10 | RSPM (R 4.4.0) |
-| hms               | 1.1.3         | 2023-03-21 | RSPM (R 4.4.0) |
-| htmlTable         | 2.4.3         | 2024-07-21 | RSPM (R 4.4.0) |
-| htmltools         | 0.5.8.1       | 2024-04-04 | RSPM (R 4.4.0) |
-| htmlwidgets       | 1.6.4         | 2023-12-06 | RSPM (R 4.4.0) |
-| httpuv            | 1.6.15        | 2024-03-26 | RSPM (R 4.4.0) |
-| httr              | 1.4.7         | 2023-08-15 | RSPM (R 4.4.0) |
-| httr2             | 1.1.0         | 2025-01-18 | RSPM (R 4.4.0) |
-| ids               | 1.0.1         | 2017-05-31 | RSPM (R 4.4.0) |
-| igraph            | 2.1.4         | 2025-01-23 | RSPM (R 4.4.0) |
-| ini               | 0.3.1         | 2018-05-20 | RSPM (R 4.4.0) |
-| insight           | 1.0.2         | 2025-02-06 | RSPM (R 4.4.0) |
-| isoband           | 0.2.7         | 2022-12-20 | RSPM (R 4.4.0) |
-| iterators         | 1.0.14        | 2022-02-05 | RSPM (R 4.4.0) |
-| jomo              | 2.7-6         | 2023-04-15 | RSPM (R 4.4.0) |
-| jpeg              | 0.1-10        | 2022-11-29 | RSPM (R 4.4.0) |
-| jquerylib         | 0.1.4         | 2021-04-26 | RSPM (R 4.4.0) |
-| jsonlite          | 1.9.0         | 2025-02-19 | RSPM (R 4.4.0) |
-| juicyjuice        | 0.1.0         | 2022-11-10 | RSPM (R 4.4.0) |
-| katex             | 1.5.0         | 2024-09-29 | RSPM (R 4.4.0) |
-| KernSmooth        | 2.23-26       | 2025-01-01 | RSPM (R 4.4.0) |
-| km.ci             | 0.5-6         | 2022-04-06 | RSPM (R 4.4.0) |
-| KMsurv            | 0.1-5         | 2012-12-03 | RSPM (R 4.4.0) |
-| knitr             | 1.49          | 2024-11-08 | RSPM (R 4.4.0) |
-| labeling          | 0.4.3         | 2023-08-29 | RSPM (R 4.4.0) |
-| later             | 1.4.1         | 2024-11-27 | RSPM (R 4.4.0) |
-| lattice           | 0.22-6        | 2024-03-20 | CRAN (R 4.4.2) |
-| lifecycle         | 1.0.4         | 2023-11-07 | RSPM (R 4.4.0) |
-| listenv           | 0.9.1         | 2024-01-29 | RSPM (R 4.4.0) |
-| littler           | 0.3.20        | 2024-03-23 | RSPM (R 4.4.2) |
-| lme4              | 1.1-36        | 2025-01-11 | RSPM (R 4.4.0) |
-| lubridate         | 1.9.4         | 2024-12-08 | RSPM (R 4.4.0) |
-| magrittr          | 2.0.3         | 2022-03-30 | RSPM (R 4.4.0) |
-| markdown          | 1.13          | 2024-06-04 | RSPM (R 4.4.0) |
-| MASS              | 7.3-64        | 2025-01-04 | RSPM (R 4.4.0) |
-| Matrix            | 1.7-2         | 2025-01-23 | RSPM (R 4.4.0) |
-| MatrixModels      | 0.5-3         | 2023-11-06 | RSPM (R 4.4.0) |
-| maxstat           | 0.7-25        | 2017-03-02 | RSPM (R 4.4.0) |
-| memoise           | 2.0.1         | 2021-11-26 | RSPM (R 4.4.0) |
-| mgcv              | 1.9-1         | 2023-12-21 | CRAN (R 4.4.2) |
-| mice              | 3.17.0        | 2024-11-27 | RSPM (R 4.4.0) |
-| microbenchmark    | 1.5.0         | 2024-09-04 | RSPM (R 4.4.0) |
-| mime              | 0.12          | 2021-09-28 | RSPM (R 4.4.0) |
-| minidown          | 0.4.0         | 2022-02-08 | RSPM (R 4.4.0) |
-| miniUI            | 0.1.1.1       | 2018-05-18 | RSPM (R 4.4.0) |
-| minqa             | 1.2.8         | 2024-08-17 | RSPM (R 4.4.0) |
-| mitml             | 0.4-5         | 2023-03-08 | RSPM (R 4.4.0) |
-| modelr            | 0.1.11        | 2023-03-22 | RSPM (R 4.4.0) |
-| munsell           | 0.5.1         | 2024-04-01 | RSPM (R 4.4.0) |
-| mvtnorm           | 1.3-3         | 2025-01-10 | RSPM (R 4.4.0) |
-| nlme              | 3.1-167       | 2025-01-27 | RSPM (R 4.4.0) |
-| nloptr            | 2.1.1         | 2024-06-25 | RSPM (R 4.4.0) |
-| nnet              | 7.3-20        | 2025-01-01 | RSPM (R 4.4.0) |
-| numDeriv          | 2016.8-1.1    | 2019-06-06 | RSPM (R 4.4.0) |
-| officer           | 0.6.7         | 2024-10-09 | RSPM (R 4.4.0) |
-| openssl           | 2.3.2         | 2025-02-03 | RSPM (R 4.4.0) |
-| openxlsx          | 4.2.8         | 2025-01-25 | RSPM (R 4.4.0) |
-| ordinal           | 2023.12-4.1   | 2024-08-19 | RSPM (R 4.4.0) |
-| pacman            | 0.5.1         | 2019-03-11 | RSPM (R 4.4.0) |
-| pak               | 0.8.0.1       | 2025-01-16 | RSPM (R 4.4.0) |
-| palmerpenguins    | 0.1.1         | 2022-08-15 | RSPM (R 4.4.0) |
-| pan               | 1.9           | 2023-12-07 | RSPM (R 4.4.0) |
-| parallelly        | 1.42.0        | 2025-01-30 | RSPM (R 4.4.0) |
-| patchwork         | 1.3.0         | 2024-09-16 | RSPM (R 4.4.0) |
-| pbkrtest          | 0.5.3         | 2024-06-26 | RSPM (R 4.4.0) |
-| pillar            | 1.10.1        | 2025-01-07 | RSPM (R 4.4.0) |
-| pkgbuild          | 1.4.6         | 2025-01-16 | RSPM (R 4.4.0) |
-| pkgconfig         | 2.0.3         | 2019-09-22 | RSPM (R 4.4.0) |
-| pkgdown           | 2.1.1         | 2024-09-17 | RSPM (R 4.4.0) |
-| pkgload           | 1.4.0         | 2024-06-28 | RSPM (R 4.4.0) |
-| plogr             | 0.2.0         | 2018-03-25 | RSPM (R 4.4.0) |
-| plyr              | 1.8.9         | 2023-10-02 | RSPM (R 4.4.0) |
-| png               | 0.1-8         | 2022-11-29 | RSPM (R 4.4.0) |
-| polynom           | 1.4-1         | 2022-04-11 | RSPM (R 4.4.0) |
-| praise            | 1.0.0         | 2015-08-11 | RSPM (R 4.4.0) |
-| prettyunits       | 1.2.0         | 2023-09-24 | RSPM (R 4.4.0) |
-| pROC              | 1.18.5        | 2023-11-01 | RSPM (R 4.4.0) |
-| processx          | 3.8.6         | 2025-02-21 | RSPM (R 4.4.0) |
-| profvis           | 0.4.0         | 2024-09-20 | RSPM (R 4.4.0) |
-| progress          | 1.2.3         | 2023-12-06 | RSPM (R 4.4.0) |
-| promises          | 1.3.2         | 2024-11-28 | RSPM (R 4.4.0) |
-| ps                | 1.9.0         | 2025-02-18 | RSPM (R 4.4.0) |
-| purrr             | 1.0.4         | 2025-02-05 | RSPM (R 4.4.0) |
-| quantreg          | 6.00          | 2025-01-29 | RSPM (R 4.4.0) |
-| quarto            | 1.4.4         | 2024-07-20 | RSPM (R 4.4.0) |
-| R.cache           | 0.16.0        | 2022-07-21 | RSPM (R 4.4.0) |
-| R.methodsS3       | 1.8.2         | 2022-06-13 | RSPM (R 4.4.0) |
-| R.oo              | 1.27.0        | 2024-11-01 | RSPM (R 4.4.0) |
-| R.utils           | 2.13.0        | 2025-02-24 | RSPM (R 4.4.0) |
-| R6                | 2.6.1         | 2025-02-15 | RSPM (R 4.4.0) |
-| ragg              | 1.3.3         | 2024-09-11 | RSPM (R 4.4.0) |
-| rappdirs          | 0.3.3         | 2021-01-31 | RSPM (R 4.4.0) |
-| rbibutils         | 2.3           | 2024-10-04 | RSPM (R 4.4.0) |
-| rcmdcheck         | 1.4.0         | 2021-09-27 | RSPM (R 4.4.0) |
-| RColorBrewer      | 1.1-3         | 2022-04-03 | RSPM (R 4.4.0) |
-| Rcpp              | 1.0.14        | 2025-01-12 | RSPM (R 4.4.0) |
-| RcppEigen         | 0.3.4.0.2     | 2024-08-24 | RSPM (R 4.4.0) |
-| RcppTOML          | 0.2.2         | 2023-01-29 | RSPM (R 4.4.0) |
-| Rdpack            | 2.6.2         | 2024-11-15 | RSPM (R 4.4.0) |
-| reactable         | 0.4.4         | 2023-03-12 | RSPM (R 4.4.0) |
-| reactR            | 0.6.1         | 2024-09-14 | RSPM (R 4.4.0) |
-| readr             | 2.1.5         | 2024-01-10 | RSPM (R 4.4.0) |
-| readxl            | 1.4.3         | 2023-07-06 | RSPM (R 4.4.0) |
-| reformulas        | 0.4.0         | 2024-11-03 | RSPM (R 4.4.0) |
-| rematch           | 2.0.0         | 2023-08-30 | RSPM (R 4.4.0) |
-| rematch2          | 2.1.2         | 2020-05-01 | RSPM (R 4.4.0) |
-| remotes           | 2.5.0         | 2024-03-17 | RSPM (R 4.4.0) |
-| reprex            | 2.1.1         | 2024-07-06 | RSPM (R 4.4.0) |
-| reticulate        | 1.41.0        | 2025-02-24 | RSPM (R 4.4.0) |
-| rgl               | 1.3.17        | 2025-01-17 | RSPM (R 4.4.0) |
-| rlang             | 1.1.5         | 2025-01-17 | RSPM (R 4.4.0) |
-| rmarkdown         | 2.29          | 2024-11-04 | RSPM (R 4.4.0) |
-| roxygen2          | 7.3.2         | 2024-06-28 | RSPM (R 4.4.0) |
-| rpart             | 4.1.24        | 2025-01-07 | RSPM (R 4.4.0) |
-| rprojroot         | 2.0.4         | 2023-11-05 | RSPM (R 4.4.0) |
-| RSQLite           | 2.3.9         | 2024-12-03 | RSPM (R 4.4.0) |
-| rstatix           | 0.7.2         | 2023-02-01 | RSPM (R 4.4.0) |
-| rstudioapi        | 0.17.1        | 2024-10-22 | RSPM (R 4.4.0) |
-| rversions         | 2.1.2         | 2022-08-31 | RSPM (R 4.4.0) |
-| rvest             | 1.0.4         | 2024-02-12 | RSPM (R 4.4.0) |
-| rvg               | 0.3.4         | 2024-08-27 | RSPM (R 4.4.0) |
-| sass              | 0.4.9         | 2024-03-15 | RSPM (R 4.4.0) |
-| scales            | 1.3.0         | 2023-11-28 | RSPM (R 4.4.0) |
-| selectr           | 0.4-2         | 2019-11-20 | RSPM (R 4.4.0) |
-| sessioninfo       | 1.2.3         | 2025-02-05 | RSPM (R 4.4.0) |
-| shape             | 1.4.6.1       | 2024-02-23 | RSPM (R 4.4.0) |
-| shiny             | 1.10.0        | 2024-12-14 | RSPM (R 4.4.0) |
-| sourcetools       | 0.1.7-1       | 2023-02-01 | RSPM (R 4.4.0) |
-| SparseM           | 1.84-2        | 2024-07-17 | RSPM (R 4.4.0) |
-| spatial           | 7.3-18        | 2025-01-01 | RSPM (R 4.4.0) |
-| stargazer         | 5.2.3         | 2022-03-04 | RSPM (R 4.4.0) |
-| stringi           | 1.8.4         | 2024-05-06 | RSPM (R 4.4.0) |
-| stringr           | 1.5.1         | 2023-11-14 | RSPM (R 4.4.0) |
-| styler            | 1.10.3        | 2024-04-07 | RSPM (R 4.4.0) |
-| survival          | 3.8-3         | 2024-12-17 | RSPM (R 4.4.0) |
-| survminer         | 0.5.0         | 2024-10-30 | RSPM (R 4.4.0) |
-| survMisc          | 0.5.6         | 2022-04-07 | RSPM (R 4.4.0) |
-| svglite           | 2.1.3         | 2023-12-08 | RSPM (R 4.4.0) |
-| sys               | 3.4.3         | 2024-10-04 | RSPM (R 4.4.0) |
-| systemfonts       | 1.2.1         | 2025-01-20 | RSPM (R 4.4.0) |
-| testthat          | 3.2.3         | 2025-01-13 | RSPM (R 4.4.0) |
-| textshaping       | 1.0.0         | 2025-01-20 | RSPM (R 4.4.0) |
-| tibble            | 3.2.1         | 2023-03-20 | RSPM (R 4.4.0) |
-| tidylog           | 1.1.0         | 2024-05-08 | RSPM (R 4.4.0) |
-| tidyplots         | 0.2.1         | 2025-01-19 | RSPM (R 4.4.0) |
-| tidyr             | 1.3.1         | 2024-01-24 | RSPM (R 4.4.0) |
-| tidyselect        | 1.2.1         | 2024-03-11 | RSPM (R 4.4.0) |
-| tidyverse         | 2.0.0         | 2023-02-22 | RSPM (R 4.4.0) |
-| timechange        | 0.3.0         | 2024-01-18 | RSPM (R 4.4.0) |
-| tinytable         | 0.7.0         | 2025-01-24 | RSPM (R 4.4.0) |
-| tinytex           | 0.56          | 2025-02-26 | RSPM (R 4.4.0) |
-| TMB               | 1.9.16        | 2025-01-08 | RSPM (R 4.4.0) |
-| tzdb              | 0.4.0         | 2023-05-12 | RSPM (R 4.4.0) |
-| ucminf            | 1.2.2         | 2024-06-24 | RSPM (R 4.4.0) |
-| urlchecker        | 1.0.1         | 2021-11-30 | RSPM (R 4.4.0) |
-| usethis           | 3.1.0         | 2024-11-26 | RSPM (R 4.4.0) |
-| utf8              | 1.2.4         | 2023-10-22 | RSPM (R 4.4.0) |
-| uuid              | 1.2-1         | 2024-07-29 | RSPM (R 4.4.0) |
-| V8                | 6.0.1         | 2025-02-02 | RSPM (R 4.4.0) |
-| vctrs             | 0.6.5         | 2023-12-01 | RSPM (R 4.4.0) |
-| vipor             | 0.4.7         | 2023-12-18 | RSPM (R 4.4.0) |
-| viridis           | 0.6.5         | 2024-01-29 | RSPM (R 4.4.0) |
-| viridisLite       | 0.4.2         | 2023-05-02 | RSPM (R 4.4.0) |
-| visNetwork        | 2.1.2         | 2022-09-29 | RSPM (R 4.4.0) |
-| vroom             | 1.6.5         | 2023-12-05 | RSPM (R 4.4.0) |
-| waldo             | 0.6.1         | 2024-11-07 | RSPM (R 4.4.0) |
-| whisker           | 0.4.1         | 2022-12-05 | RSPM (R 4.4.0) |
-| withr             | 3.0.2         | 2024-10-28 | RSPM (R 4.4.0) |
-| xfun              | 0.51          | 2025-02-19 | RSPM (R 4.4.0) |
-| xml2              | 1.3.6         | 2023-12-04 | RSPM (R 4.4.0) |
-| xopen             | 1.0.1         | 2024-04-25 | RSPM (R 4.4.0) |
-| xtable            | 1.8-4         | 2019-04-21 | RSPM (R 4.4.0) |
-| yaml              | 2.3.10        | 2024-07-26 | RSPM (R 4.4.0) |
-| zip               | 2.3.2         | 2025-02-01 | RSPM (R 4.4.0) |
-| zoo               | 1.8-13        | 2025-02-22 | RSPM (R 4.4.0) |
+| abind             | 1.4-8         | 2024-09-12 | RSPM           |
+| askpass           | 1.2.1         | 2024-10-04 | RSPM (R 4.5.0) |
+| backports         | 1.5.0         | 2024-05-23 | RSPM (R 4.5.0) |
+| base64enc         | 0.1-3         | 2015-07-28 | RSPM (R 4.5.0) |
+| basepenguins      | 0.1.0         | 2025-04-08 | RSPM           |
+| beeswarm          | 0.4.0         | 2021-06-01 | RSPM           |
+| bigD              | 0.3.1         | 2025-04-03 | RSPM           |
+| BiocManager       | 1.30.26       | 2025-06-05 | RSPM (R 4.5.0) |
+| bit               | 4.6.0         | 2025-03-06 | RSPM (R 4.5.0) |
+| bit64             | 4.6.0-1       | 2025-01-16 | RSPM (R 4.5.0) |
+| bitops            | 1.0-9         | 2024-10-03 | RSPM           |
+| blob              | 1.2.4         | 2023-03-17 | RSPM (R 4.5.0) |
+| boot              | 1.3-31        | 2024-08-28 | CRAN (R 4.5.0) |
+| brew              | 1.0-10        | 2023-12-16 | RSPM (R 4.5.0) |
+| brio              | 1.1.5         | 2024-04-24 | RSPM (R 4.5.0) |
+| broom             | 1.0.8         | 2025-03-28 | RSPM (R 4.5.0) |
+| bslib             | 0.9.0         | 2025-01-30 | RSPM (R 4.5.0) |
+| cachem            | 1.1.0         | 2024-05-16 | RSPM (R 4.5.0) |
+| Cairo             | 1.6-2         | 2023-11-28 | RSPM           |
+| callr             | 3.7.6         | 2024-03-25 | RSPM (R 4.5.0) |
+| car               | 3.1-3         | 2024-09-27 | RSPM           |
+| carData           | 3.0-5         | 2022-01-06 | RSPM           |
+| cards             | 0.6.0         | 2025-04-11 | RSPM           |
+| cellranger        | 1.1.0         | 2016-07-27 | RSPM (R 4.5.0) |
+| checkmate         | 2.3.2         | 2024-07-29 | RSPM           |
+| class             | 7.3-23        | 2025-01-01 | CRAN (R 4.5.0) |
+| cli               | 3.6.5         | 2025-04-23 | RSPM (R 4.5.0) |
+| clipr             | 0.8.0         | 2022-02-22 | RSPM (R 4.5.0) |
+| clisymbols        | 1.2.0         | 2017-05-21 | RSPM           |
+| cluster           | 2.1.8.1       | 2025-03-12 | CRAN (R 4.5.0) |
+| cmprsk            | 2.2-12        | 2024-05-19 | RSPM           |
+| codetools         | 0.2-20        | 2024-03-31 | CRAN (R 4.5.0) |
+| colorspace        | 2.1-1         | 2024-07-26 | RSPM           |
+| commonmark        | 1.9.5         | 2025-03-17 | RSPM (R 4.5.0) |
+| conflicted        | 1.2.0         | 2023-02-01 | RSPM (R 4.5.0) |
+| corrplot          | 0.95          | 2024-10-14 | RSPM           |
+| cowplot           | 1.1.3         | 2024-01-22 | RSPM           |
+| cpp11             | 0.5.2         | 2025-03-03 | RSPM (R 4.5.0) |
+| crayon            | 1.5.3         | 2024-06-20 | RSPM (R 4.5.0) |
+| credentials       | 2.0.2         | 2024-10-04 | RSPM (R 4.5.0) |
+| curl              | 6.3.0         | 2025-06-06 | RSPM (R 4.5.0) |
+| data.table        | 1.17.4        | 2025-05-26 | RSPM (R 4.5.0) |
+| datawizard        | 1.1.0         | 2025-05-09 | RSPM           |
+| DBI               | 1.2.3         | 2024-06-02 | RSPM (R 4.5.0) |
+| dbplyr            | 2.5.0         | 2024-03-19 | RSPM (R 4.5.0) |
+| Deriv             | 4.1.6         | 2024-09-13 | RSPM           |
+| desc              | 1.4.3         | 2023-12-10 | RSPM (R 4.5.0) |
+| devEMF            | 4.5-1         | 2025-03-24 | RSPM           |
+| devtools          | 2.4.5         | 2022-10-11 | RSPM (R 4.5.0) |
+| DiagrammeR        | 1.0.11        | 2024-02-02 | RSPM           |
+| diffobj           | 0.3.6         | 2025-04-21 | RSPM (R 4.5.0) |
+| digest            | 0.6.37        | 2024-08-19 | RSPM (R 4.5.0) |
+| doBy              | 4.6.27        | 2025-05-16 | RSPM           |
+| docopt            | 0.7.2         | 2025-03-25 | RSPM (R 4.5.0) |
+| downlit           | 0.4.4         | 2024-06-10 | RSPM (R 4.5.0) |
+| dplyr             | 1.1.4         | 2023-11-17 | RSPM (R 4.5.0) |
+| dtplyr            | 1.3.1         | 2023-03-22 | RSPM (R 4.5.0) |
+| ellipsis          | 0.3.2         | 2021-04-29 | RSPM (R 4.5.0) |
+| evaluate          | 1.0.3         | 2025-01-10 | RSPM (R 4.5.0) |
+| exactRankTests    | 0.8-35        | 2022-04-26 | RSPM           |
+| export            | 0.3.0         | 2022-12-07 | RSPM           |
+| fansi             | 1.0.6         | 2023-12-08 | RSPM (R 4.5.0) |
+| farver            | 2.1.2         | 2024-05-13 | RSPM (R 4.5.0) |
+| fastmap           | 1.2.0         | 2024-05-15 | RSPM (R 4.5.0) |
+| flextable         | 0.9.9         | 2025-05-31 | RSPM           |
+| fontawesome       | 0.5.3         | 2024-11-16 | RSPM (R 4.5.0) |
+| fontBitstreamVera | 0.1.1         | 2017-02-01 | RSPM           |
+| fontLiberation    | 0.1.0         | 2016-10-15 | RSPM           |
+| fontquiver        | 0.2.1         | 2017-02-01 | RSPM           |
+| forcats           | 1.0.0         | 2023-01-29 | RSPM (R 4.5.0) |
+| foreach           | 1.5.2         | 2022-02-02 | RSPM           |
+| foreign           | 0.8-90        | 2025-03-31 | CRAN (R 4.5.0) |
+| formattable       | 0.2.1         | 2021-01-07 | RSPM           |
+| Formula           | 1.2-5         | 2023-02-24 | RSPM           |
+| fs                | 1.6.6         | 2025-04-12 | RSPM (R 4.5.0) |
+| fst               | 0.9.8         | 2022-02-08 | RSPM (R 4.5.0) |
+| fstcore           | 0.10.0        | 2025-02-10 | RSPM (R 4.5.0) |
+| ftExtra           | 0.6.4         | 2024-05-10 | RSPM           |
+| furrr             | 0.3.1         | 2022-08-15 | RSPM           |
+| future            | 1.58.0        | 2025-06-05 | RSPM           |
+| gargle            | 1.5.2         | 2023-07-20 | RSPM (R 4.5.0) |
+| gdtools           | 0.4.2         | 2025-03-27 | RSPM           |
+| generics          | 0.1.4         | 2025-05-09 | RSPM (R 4.5.0) |
+| gert              | 2.1.5         | 2025-03-25 | RSPM (R 4.5.0) |
+| GGally            | 2.2.1         | 2024-02-14 | RSPM           |
+| ggbeeswarm        | 0.7.2         | 2023-04-29 | RSPM           |
+| ggeffects         | 2.2.1         | 2025-03-11 | RSPM           |
+| ggfortify         | 0.4.17        | 2024-04-17 | RSPM           |
+| gghighlight       | 0.4.1         | 2023-12-16 | RSPM           |
+| ggmice            | 0.1.0         | 2023-08-07 | RSPM           |
+| ggplot2           | 3.5.2         | 2025-04-09 | RSPM (R 4.5.0) |
+| ggpubr            | 0.6.0         | 2023-02-10 | RSPM           |
+| ggrastr           | 1.0.2         | 2023-06-01 | RSPM           |
+| ggrepel           | 0.9.6         | 2024-09-07 | RSPM           |
+| ggsci             | 3.2.0         | 2024-06-18 | RSPM           |
+| ggsignif          | 0.6.4         | 2022-10-13 | RSPM           |
+| ggstats           | 0.9.0         | 2025-03-10 | RSPM           |
+| ggsurvfit         | 1.1.0         | 2024-05-08 | RSPM           |
+| ggtext            | 0.1.2         | 2022-09-16 | RSPM           |
+| gh                | 1.5.0         | 2025-05-26 | RSPM (R 4.5.0) |
+| gitcreds          | 0.1.2         | 2022-09-08 | RSPM (R 4.5.0) |
+| glmmTMB           | 1.1.11        | 2025-04-02 | RSPM           |
+| glmnet            | 4.1-9         | 2025-06-02 | RSPM           |
+| glmnetUtils       | 1.1.9         | 2023-09-10 | RSPM           |
+| globals           | 0.18.0        | 2025-05-08 | RSPM           |
+| glue              | 1.8.0         | 2024-09-30 | RSPM (R 4.5.0) |
+| googledrive       | 2.1.1         | 2023-06-11 | RSPM (R 4.5.0) |
+| googlesheets4     | 1.1.1         | 2023-06-11 | RSPM (R 4.5.0) |
+| gridExtra         | 2.3           | 2017-09-09 | RSPM           |
+| gridtext          | 0.1.5         | 2022-09-16 | RSPM           |
+| gt                | 1.0.0         | 2025-04-05 | RSPM           |
+| gtable            | 0.3.6         | 2024-10-25 | RSPM (R 4.5.0) |
+| gtsummary         | 2.2.0         | 2025-04-14 | RSPM           |
+| haven             | 2.5.5         | 2025-05-30 | RSPM (R 4.5.0) |
+| here              | 1.0.1         | 2020-12-13 | RSPM           |
+| highr             | 0.11          | 2024-05-26 | RSPM (R 4.5.0) |
+| Hmisc             | 5.2-3         | 2025-03-16 | RSPM           |
+| hms               | 1.1.3         | 2023-03-21 | RSPM (R 4.5.0) |
+| htmlTable         | 2.4.3         | 2024-07-21 | RSPM           |
+| htmltools         | 0.5.8.1       | 2024-04-04 | RSPM (R 4.5.0) |
+| htmlwidgets       | 1.6.4         | 2023-12-06 | RSPM (R 4.5.0) |
+| httpuv            | 1.6.16        | 2025-04-16 | RSPM (R 4.5.0) |
+| httr              | 1.4.7         | 2023-08-15 | RSPM (R 4.5.0) |
+| httr2             | 1.1.2         | 2025-03-26 | RSPM (R 4.5.0) |
+| ids               | 1.0.1         | 2017-05-31 | RSPM (R 4.5.0) |
+| igraph            | 2.1.4         | 2025-01-23 | RSPM           |
+| ini               | 0.3.1         | 2018-05-20 | RSPM (R 4.5.0) |
+| insight           | 1.3.0         | 2025-05-20 | RSPM           |
+| isoband           | 0.2.7         | 2022-12-20 | RSPM (R 4.5.0) |
+| iterators         | 1.0.14        | 2022-02-05 | RSPM           |
+| jomo              | 2.7-6         | 2023-04-15 | RSPM           |
+| jpeg              | 0.1-11        | 2025-03-21 | RSPM           |
+| jquerylib         | 0.1.4         | 2021-04-26 | RSPM (R 4.5.0) |
+| jsonlite          | 2.0.0         | 2025-03-27 | RSPM (R 4.5.0) |
+| juicyjuice        | 0.1.0         | 2022-11-10 | RSPM           |
+| katex             | 1.5.0         | 2024-09-29 | RSPM           |
+| KernSmooth        | 2.23-26       | 2025-01-01 | CRAN (R 4.5.0) |
+| km.ci             | 0.5-6         | 2022-04-06 | RSPM           |
+| KMsurv            | 0.1-6         | 2025-05-20 | RSPM           |
+| knitr             | 1.50          | 2025-03-16 | RSPM           |
+| labeling          | 0.4.3         | 2023-08-29 | RSPM (R 4.5.0) |
+| later             | 1.4.2         | 2025-04-08 | RSPM (R 4.5.0) |
+| lattice           | 0.22-7        | 2025-04-02 | RSPM (R 4.5.0) |
+| lifecycle         | 1.0.4         | 2023-11-07 | RSPM (R 4.5.0) |
+| listenv           | 0.9.1         | 2024-01-29 | RSPM           |
+| litedown          | 0.7           | 2025-04-08 | RSPM           |
+| littler           | 0.3.21        | 2025-03-25 | RSPM (R 4.5.0) |
+| lme4              | 1.1-37        | 2025-03-26 | RSPM           |
+| lubridate         | 1.9.4         | 2024-12-08 | RSPM (R 4.5.0) |
+| magrittr          | 2.0.3         | 2022-03-30 | RSPM (R 4.5.0) |
+| markdown          | 2.0           | 2025-03-23 | RSPM           |
+| MASS              | 7.3-65        | 2025-02-28 | CRAN (R 4.5.0) |
+| Matrix            | 1.7-3         | 2025-03-11 | CRAN (R 4.5.0) |
+| MatrixModels      | 0.5-4         | 2025-03-26 | RSPM           |
+| maxstat           | 0.7-26        | 2025-05-02 | RSPM           |
+| memoise           | 2.0.1         | 2021-11-26 | RSPM (R 4.5.0) |
+| mgcv              | 1.9-3         | 2025-04-04 | RSPM (R 4.5.0) |
+| mice              | 3.18.0        | 2025-05-27 | RSPM           |
+| microbenchmark    | 1.5.0         | 2024-09-04 | RSPM           |
+| mime              | 0.13          | 2025-03-17 | RSPM (R 4.5.0) |
+| minidown          | 0.4.0         | 2022-02-08 | RSPM           |
+| miniUI            | 0.1.2         | 2025-04-17 | RSPM (R 4.5.0) |
+| minqa             | 1.2.8         | 2024-08-17 | RSPM           |
+| mitml             | 0.4-5         | 2023-03-08 | RSPM           |
+| modelr            | 0.1.11        | 2023-03-22 | RSPM (R 4.5.0) |
+| mvtnorm           | 1.3-3         | 2025-01-10 | RSPM           |
+| nlme              | 3.1-168       | 2025-03-31 | CRAN (R 4.5.0) |
+| nloptr            | 2.2.1         | 2025-03-17 | RSPM           |
+| nnet              | 7.3-20        | 2025-01-01 | CRAN (R 4.5.0) |
+| numDeriv          | 2016.8-1.1    | 2019-06-06 | RSPM           |
+| officer           | 0.6.10        | 2025-05-30 | RSPM           |
+| openssl           | 2.3.3         | 2025-05-26 | RSPM (R 4.5.0) |
+| openxlsx          | 4.2.8         | 2025-01-25 | RSPM           |
+| ordinal           | 2023.12-4.1   | 2024-08-19 | RSPM           |
+| pacman            | 0.5.1         | 2019-03-11 | RSPM           |
+| pak               | 0.9.0         | 2025-05-27 | RSPM (R 4.5.0) |
+| palmerpenguins    | 0.1.1         | 2022-08-15 | RSPM           |
+| pan               | 1.9           | 2023-12-07 | RSPM           |
+| parallelly        | 1.45.0        | 2025-06-02 | RSPM           |
+| patchwork         | 1.3.0         | 2024-09-16 | RSPM           |
+| pbkrtest          | 0.5.4         | 2025-04-28 | RSPM           |
+| pillar            | 1.10.2        | 2025-04-05 | RSPM (R 4.5.0) |
+| pkgbuild          | 1.4.8         | 2025-05-26 | RSPM (R 4.5.0) |
+| pkgconfig         | 2.0.3         | 2019-09-22 | RSPM (R 4.5.0) |
+| pkgdown           | 2.1.3         | 2025-05-25 | RSPM (R 4.5.0) |
+| pkgload           | 1.4.0         | 2024-06-28 | RSPM (R 4.5.0) |
+| plogr             | 0.2.0         | 2018-03-25 | RSPM (R 4.5.0) |
+| plyr              | 1.8.9         | 2023-10-02 | RSPM           |
+| png               | 0.1-8         | 2022-11-29 | RSPM           |
+| polynom           | 1.4-1         | 2022-04-11 | RSPM           |
+| praise            | 1.0.0         | 2015-08-11 | RSPM (R 4.5.0) |
+| prettyunits       | 1.2.0         | 2023-09-24 | RSPM (R 4.5.0) |
+| pROC              | 1.18.5        | 2023-11-01 | RSPM           |
+| processx          | 3.8.6         | 2025-02-21 | RSPM (R 4.5.0) |
+| profvis           | 0.4.0         | 2024-09-20 | RSPM (R 4.5.0) |
+| progress          | 1.2.3         | 2023-12-06 | RSPM (R 4.5.0) |
+| promises          | 1.3.3         | 2025-05-29 | RSPM (R 4.5.0) |
+| ps                | 1.9.1         | 2025-04-12 | RSPM (R 4.5.0) |
+| purrr             | 1.0.4         | 2025-02-05 | RSPM (R 4.5.0) |
+| quantreg          | 6.1           | 2025-03-10 | RSPM           |
+| quarto            | 1.4.4         | 2024-07-20 | RSPM           |
+| R.cache           | 0.17.0        | 2025-05-02 | RSPM           |
+| R.methodsS3       | 1.8.2         | 2022-06-13 | RSPM           |
+| R.oo              | 1.27.1        | 2025-05-02 | RSPM           |
+| R.utils           | 2.13.0        | 2025-02-24 | RSPM           |
+| R6                | 2.6.1         | 2025-02-15 | RSPM (R 4.5.0) |
+| ragg              | 1.4.0         | 2025-04-10 | RSPM (R 4.5.0) |
+| rappdirs          | 0.3.3         | 2021-01-31 | RSPM (R 4.5.0) |
+| rbibutils         | 2.3           | 2024-10-04 | RSPM           |
+| rcmdcheck         | 1.4.0         | 2021-09-27 | RSPM (R 4.5.0) |
+| RColorBrewer      | 1.1-3         | 2022-04-03 | RSPM (R 4.5.0) |
+| Rcpp              | 1.0.14        | 2025-01-12 | RSPM (R 4.5.0) |
+| RcppEigen         | 0.3.4.0.2     | 2024-08-24 | RSPM (R 4.5.0) |
+| RcppTOML          | 0.2.3         | 2025-03-08 | RSPM (R 4.5.0) |
+| Rdpack            | 2.6.4         | 2025-04-09 | RSPM           |
+| reactable         | 0.4.4         | 2023-03-12 | RSPM           |
+| reactR            | 0.6.1         | 2024-09-14 | RSPM           |
+| readr             | 2.1.5         | 2024-01-10 | RSPM (R 4.5.0) |
+| readxl            | 1.4.5         | 2025-03-07 | RSPM (R 4.5.0) |
+| reformulas        | 0.4.1         | 2025-04-30 | RSPM           |
+| rematch           | 2.0.0         | 2023-08-30 | RSPM (R 4.5.0) |
+| rematch2          | 2.1.2         | 2020-05-01 | RSPM (R 4.5.0) |
+| remotes           | 2.5.0         | 2024-03-17 | RSPM (R 4.5.0) |
+| reprex            | 2.1.1         | 2024-07-06 | RSPM (R 4.5.0) |
+| reticulate        | 1.42.0        | 2025-03-25 | RSPM (R 4.5.0) |
+| rgl               | 1.3.18        | 2025-03-28 | RSPM           |
+| rlang             | 1.1.6         | 2025-04-11 | RSPM (R 4.5.0) |
+| rmarkdown         | 2.29          | 2024-11-04 | RSPM (R 4.5.0) |
+| roxygen2          | 7.3.2         | 2024-06-28 | RSPM (R 4.5.0) |
+| rpart             | 4.1.24        | 2025-01-07 | CRAN (R 4.5.0) |
+| rprojroot         | 2.0.4         | 2023-11-05 | RSPM (R 4.5.0) |
+| RSQLite           | 2.4.1         | 2025-06-08 | RSPM (R 4.5.0) |
+| rstatix           | 0.7.2         | 2023-02-01 | RSPM           |
+| rstudioapi        | 0.17.1        | 2024-10-22 | RSPM (R 4.5.0) |
+| rversions         | 2.1.2         | 2022-08-31 | RSPM (R 4.5.0) |
+| rvest             | 1.0.4         | 2024-02-12 | RSPM (R 4.5.0) |
+| rvg               | 0.3.5         | 2025-03-27 | RSPM           |
+| sass              | 0.4.10        | 2025-04-11 | RSPM (R 4.5.0) |
+| scales            | 1.4.0         | 2025-04-24 | RSPM (R 4.5.0) |
+| selectr           | 0.4-2         | 2019-11-20 | RSPM (R 4.5.0) |
+| sessioninfo       | 1.2.3         | 2025-02-05 | RSPM (R 4.5.0) |
+| shape             | 1.4.6.1       | 2024-02-23 | RSPM           |
+| shiny             | 1.10.0        | 2024-12-14 | RSPM (R 4.5.0) |
+| sourcetools       | 0.1.7-1       | 2023-02-01 | RSPM (R 4.5.0) |
+| SparseM           | 1.84-2        | 2024-07-17 | RSPM           |
+| spatial           | 7.3-18        | 2025-01-01 | CRAN (R 4.5.0) |
+| stargazer         | 5.2.3         | 2022-03-04 | RSPM           |
+| stringi           | 1.8.7         | 2025-03-27 | RSPM (R 4.5.0) |
+| stringr           | 1.5.1         | 2023-11-14 | RSPM (R 4.5.0) |
+| styler            | 1.10.3        | 2024-04-07 | RSPM           |
+| survival          | 3.8-3         | 2024-12-17 | CRAN (R 4.5.0) |
+| survminer         | 0.5.0         | 2024-10-30 | RSPM           |
+| survMisc          | 0.5.6         | 2022-04-07 | RSPM           |
+| svglite           | 2.2.1         | 2025-05-12 | RSPM           |
+| sys               | 3.4.3         | 2024-10-04 | RSPM (R 4.5.0) |
+| systemfonts       | 1.2.3         | 2025-04-30 | RSPM (R 4.5.0) |
+| testthat          | 3.2.3         | 2025-01-13 | RSPM (R 4.5.0) |
+| textshaping       | 1.0.1         | 2025-05-01 | RSPM (R 4.5.0) |
+| tibble            | 3.3.0         | 2025-06-08 | RSPM (R 4.5.0) |
+| tidylog           | 1.1.0         | 2024-05-08 | RSPM           |
+| tidyplots         | 0.2.2         | 2025-03-07 | RSPM           |
+| tidyr             | 1.3.1         | 2024-01-24 | RSPM (R 4.5.0) |
+| tidyselect        | 1.2.1         | 2024-03-11 | RSPM (R 4.5.0) |
+| tidyverse         | 2.0.0         | 2023-02-22 | RSPM (R 4.5.0) |
+| timechange        | 0.3.0         | 2024-01-18 | RSPM (R 4.5.0) |
+| tinytable         | 0.9.0         | 2025-05-04 | RSPM           |
+| tinytex           | 0.57          | 2025-04-15 | RSPM (R 4.5.0) |
+| TMB               | 1.9.17        | 2025-03-10 | RSPM           |
+| tzdb              | 0.5.0         | 2025-03-15 | RSPM (R 4.5.0) |
+| ucminf            | 1.2.2         | 2024-06-24 | RSPM           |
+| urlchecker        | 1.0.1         | 2021-11-30 | RSPM (R 4.5.0) |
+| usethis           | 3.1.0         | 2024-11-26 | RSPM (R 4.5.0) |
+| utf8              | 1.2.6         | 2025-06-08 | RSPM (R 4.5.0) |
+| uuid              | 1.2-1         | 2024-07-29 | RSPM (R 4.5.0) |
+| V8                | 6.0.4         | 2025-06-04 | RSPM           |
+| vctrs             | 0.6.5         | 2023-12-01 | RSPM (R 4.5.0) |
+| vipor             | 0.4.7         | 2023-12-18 | RSPM           |
+| viridis           | 0.6.5         | 2024-01-29 | RSPM           |
+| viridisLite       | 0.4.2         | 2023-05-02 | RSPM (R 4.5.0) |
+| visNetwork        | 2.1.2         | 2022-09-29 | RSPM           |
+| vroom             | 1.6.5         | 2023-12-05 | RSPM (R 4.5.0) |
+| waldo             | 0.6.1         | 2024-11-07 | RSPM (R 4.5.0) |
+| whisker           | 0.4.1         | 2022-12-05 | RSPM (R 4.5.0) |
+| withr             | 3.0.2         | 2024-10-28 | RSPM (R 4.5.0) |
+| xfun              | 0.52          | 2025-04-02 | RSPM (R 4.5.0) |
+| xml2              | 1.3.8         | 2025-03-14 | RSPM (R 4.5.0) |
+| xopen             | 1.0.1         | 2024-04-25 | RSPM (R 4.5.0) |
+| xtable            | 1.8-4         | 2019-04-21 | RSPM (R 4.5.0) |
+| yaml              | 2.3.10        | 2024-07-26 | RSPM (R 4.5.0) |
+| zip               | 2.3.3         | 2025-05-13 | RSPM (R 4.5.0) |
+| zoo               | 1.8-14        | 2025-04-10 | RSPM           |


### PR DESCRIPTION
4.5.0_2025Jun: rocker/rstudio:4.5.0 ベースに更新

- Rパッケージのインストールを依存ライブラリのインストールもできる pak に移行
- remote SSH 接続ができるよう、sshd の作業フォルダなどを設定
- microsoft/edit をCLIでの編集用に追加
